### PR TITLE
Overhaul README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ var Todo = DS.Model.extend({
 });
 ```
 
-## Configuring app/adapters/applications.js
+## Configuring app/adapters/application.js
 
 ### Basic adapter
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ And with Ember-cli, you're only a few steps away from delivering a native app us
 Currently PouchDB doesn't use localStorage unless you include an experimental plugin. Amazingly, this is only necessary to support IE ≤ 9.0 and Opera Mini. It's recommended you read more about this, what storage mechanisms modern browsers now support, and using SQLite in Cordova here: http://pouchdb.com/adapters.html
 
 CouchDB notes:
-From day one, CouchDB and it's protocol have been designed to be always Available and handle Partitioning over the network well. PouchDB/CouchDB gives you a solid way to manage conflicts. It is 'eventually consistent', but CouchDB has an api for listening to changes to the database, which can be then pushed down to the client in real-time. With PouchDB, you also get access to a whole host of PouchDB plugins, like syncing with peers over `WebRTC`: 
+From day one, CouchDB and it's protocol have been designed to be always Available and handle Partitioning over the network well. PouchDB/CouchDB gives you a solid way to manage conflicts. It is 'eventually consistent', but CouchDB has an api for listening to changes to the database, which can be then pushed down to the client in real-time. With PouchDB, you also get access to a whole host of [PouchDB plugins](http://pouchdb.com/external.html)
 
 This module is really just a thin layer of Ember-y goodness over [Relational Pouch](https://github.com/nolanlawson/relational-pouch). Before you file an issue, please check to see if it's more appropriate to file over there.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ export default EmberPouch.Adapter.extend({
 Example: https://github.com/broerse/ember-cli-blog
 
 For more on `EmberPouch`, there are only 150 meaningful lines of code for this project located here: https://github.com/nolanlawson/ember-pouch/blob/master/lib/pouchdb-adapter.js
+Everything else is handled in the `Relational-Pouch` PouchDB plugin, read those api docs here: https://github.com/nolanlawson/relational-pouch#api
 
 For more on PouchDB: [PouchDB.com](http://pouchdb.com).
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,21 @@
 # Ember Pouch
 
-Ember Pouch is a PouchDB/CouchDB adapter for Ember Data.
+With the **`EmberPouch`** Ember Data Adapter, your Ember app's data is automatically cached/saved client side using whatever storage mechanisms are available (IndexedDB, WebSQL), and you're setup to easily sync with any backend implementing the CouchDB protocol. Throw in an html5 **appcache.manifest** with [**broccoli-manifest**](https://github.com/racido/broccoli-manifest) and now you have a highly functional [_**offline-first**_](http://offlinefirst.org/) web **App**. Your web app will load faster than even the lightest javascript apps because it's reading from the local disk; only using the network for data requests and transparent background updates. Stop stressing over how many kilobytes your page is!
 
-Instead of using the standard RESTAdapter or FixtureAdapter, you can sync your Ember model objects to PouchDB, and then on to CouchDB or other CouchDB-compliant servers (Cloudant, Couchbase, IrisCouch, etc.). This adds real-time sync to your Ember app, as well as making it [offline-first](http://offlinefirst.org/).
+And with Ember-cli, you're only a few steps away from delivering a native app using these [cordova addons](http://www.emberaddons.com/#/?q=cordova).
+
+Currently PouchDB doesn't use localStorage unless you include an experimental plugin. Amazingly, this is only necessary to support IE ≤ 9.0 and Opera Mini. It's recommended you read more about this, what storage mechanisms modern browsers now support, and using SQLite in Cordova here: http://pouchdb.com/adapters.html
+
+CouchDB notes:
+From day one, CouchDB and it's protocol have been designed to be always Available and handle Partitioning over the network well. PouchDB/CouchDB gives you a solid way to manage conflicts. It is 'eventually consistent', but CouchDB has an api for listening to changes to the database, which can be then pushed down to the client in real-time. With PouchDB, you also get access to a whole host of PouchDB plugins, like syncing with peers over `WebRTC`: 
 
 This module is really just a thin layer of Ember-y goodness over [Relational Pouch](https://github.com/nolanlawson/relational-pouch). Before you file an issue, please check to see if it's more appropriate to file over there.
 
 ## Installation
 
-Download the `dist/` files you want, or install with Bower:
+    bower install ember-pouch --save
 
-    $ bower install ember-pouch --save
-
-Or from npm:
-
-    $ npm install ember-pouch --save
-
-**Note:** if you *don't* install with Bower, then you will also have to manually download
-[PouchDB](https://github.com/pouchdb/pouchdb) and [relational-pouch](https://github.com/nolanlawson/relational-pouch).
-Bower installs the dependencies automatically; the others don't.
-
-Now that you have the `dist/` files locally, you just put this in your `Brocfile.js`:
+In `Brocfile.js`:
 
 ```js
 app.import('bower_components/pouchdb/dist/pouchdb.js');
@@ -28,15 +23,19 @@ app.import('bower_components/relational-pouch/dist/pouchdb.relational-pouch.js')
 app.import('bower_components/ember-pouch/dist/globals/main.js');
 ```
 
-Now you're ready to cook with Ember Pouch!
+This defines `window.PouchDB` and `window.EmberPouch` globally.
 
+In `app/adapters/application.js`:
 
-## Usage
+```js
+/* global EmberPouch, PouchDB */
 
-#### Set up your models
+export default EmberPouch.Adapter.extend({
+  db: new PouchDB('mydb') // See: http://pouchdb.com/api.html#create_database for options
+});
+```
 
-Next, you need to add a `rev` field to all of your Models. This is used by PouchDB/CouchDB
-to manage revisions:
+Currently `Ember-Pouch` needs you to **add a** `rev: DS.attr('string')` **field to all your models**. This is for Pouch/Couch to handle revisions:
 
 ```js
 var Todo = DS.Model.extend({
@@ -46,72 +45,58 @@ var Todo = DS.Model.extend({
 });
 ```
 
-If you forget to do this, you will see the error:
+## Usage
+
+You can now use PouchDB as a local database that syncs with CouchDB:
+
+```js
+/* global EmberPouch, PouchDB */
+// app/adapters/application.js
+PouchDB.debug.enable('*');
+
+var db     = new PouchDB('mydb'); // Local
+var remote = new PouchDB('http://localhost:5984/mydb', {ajax: {timeout: 20000}});
+
+var dbSync = function() {
+  db.sync(remote, {live: true})
+    .on('error', function (err) {
+      setTimeout(dbSync, 2 * 1000); // retry
+    });
+};
+dbSync();
+window.dbSync = dbSync;
+
+export default EmberPouch.Adapter.extend({
+  db: db
+});
+```
+
+Example: https://github.com/broerse/ember-cli-blog
+
+For more on `EmberPouch`, there are only 150 meaningful lines of code for this project located here: https://github.com/nolanlawson/ember-pouch/blob/master/lib/pouchdb-adapter.js
+
+For more on PouchDB: [PouchDB.com](http://pouchdb.com).
+
+## Common errors:
+
+If you forget to add a `rev` field to a model, you will see the error:
 
     Failed to load resource: the server responded with a status of 409 (Conflict)
 
 in your console.
 
-#### Set up your adapter
-
-Then, in your `application.js`, extend `EmberPouch.Adapter` and set your `PouchDB` database:
-
-```js
-export default EmberPouch.Adapter.extend({
-  db: new PouchDB('mydb')
-});
-```
-
-#### Using PouchDB
-
-If you're not familiar with PouchDB, here are some of the different ways you can use it:
-
-As a local PouchDB database:
-
-```js
-var db = new PouchDB('mydb');
-
-export default EmberPouch.Adapter.extend({
-  db: db
-});
-```
-
-As a direct client to CouchDB:
-
-```js
-var db = new PouchDB('http://localhost:5984/mydb');
- 
-export default EmberPouch.Adapter.extend({
-  db: db
-});
-```
-
-As a local database that syncs with CouchDB:
-
-```js
-var db = new PouchDB('mydb');
-var remote = new PouchDB('http://localhost:5984/mydb');
-
-function doSync() {
-  db.sync(remote, {live: true}).on('error', function (err) {
-    setTimeout(doSync, 1000); // retry
-  });
-}
-doSync();
-
-export default EmberPouch.Adapter.extend({
-  db: db
-});
-```
-
-For more info on PouchDB, see the official PouchDB documentation at [PouchDB.com](http://pouchdb.com).
 
 ## Build
 
     $ npm run build
+
+## Related projects:
+
+- [taras/ember-pouchdb](https://github.com/taras/ember-pouchdb)
 
 ## Credits
 
 This project was originally based on the [ember-data-hal-adapter](https://github.com/locks/ember-data-hal-adapter) by [@locks](https://github.com/locks), and I really benefited from his guidance during its creation.
 
 And of course thanks to all our wonderful contributors, [here](https://github.com/nolanlawson/ember-pouch/graphs/contributors) and [in relational-pouch](https://github.com/nolanlawson/relational-pouch/graphs/contributors)! 
+

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Ember Pouch
 
-With the **`EmberPouch`** Ember Data Adapter, all your app's data is automatically cached/saved client side using IndexedDB and WebSQL, and you just keep using the regular [Ember Data `store` api](http://emberjs.com/api/data/classes/DS.Store.html#method_all). 
+With the **`EmberPouch`** Ember Data Adapter, all of your app's data is automatically cached/saved client side using IndexedDB and WebSQL, and you just keep using the regular [Ember Data `store` api](http://emberjs.com/api/data/classes/DS.Store.html#method_all). 
 
 Go [_**offline-first**_](http://offlinefirst.org/) by adding an html5 **appcache.manifest** with [**broccoli-manifest**](https://github.com/racido/broccoli-manifest), and your app will also load way faster on subsequent loads over slower connections.
-Cordova/phonegap Ember plugins: [cordova addons](http://www.emberaddons.com/#/?q=cordova).
 
 ## Installation
 
@@ -29,7 +28,7 @@ var Todo = DS.Model.extend({
 });
 ```
 
-# `app/adapters/applications.js`
+## Configuring app/adapters/applications.js
 
 ### Basic adapter
 
@@ -129,7 +128,8 @@ And `/config/environment.js` would have something like this at the end:
 
 Tom Dale's blog example using Ember CLI and EmberPouch: [broerse/ember-cli-blog](https://github.com/broerse/ember-cli-blog)
 
-## Etc:
+
+## Notes:
 
 Currently PouchDB doesn't use localStorage unless you include an experimental plugin. Amazingly, this is only necessary to support IE ≤ 9.0 and Opera Mini. It's recommended you read more about this, what storage mechanisms modern browsers now support, and using SQLite in Cordova here: http://pouchdb.com/adapters.html
 
@@ -149,4 +149,5 @@ For more on PouchDB: http://pouchdb.com
 This project was originally based on the [ember-data-hal-adapter](https://github.com/locks/ember-data-hal-adapter) by [@locks](https://github.com/locks), and I really benefited from his guidance during its creation.
 
 And of course thanks to all our wonderful contributors, [here](https://github.com/nolanlawson/ember-pouch/graphs/contributors) and [in relational-pouch](https://github.com/nolanlawson/relational-pouch/graphs/contributors)! 
+
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ var remote = new PouchDB('http://foo.iriscouch.com:5984', {
   ajax: {
     timeout: 6 * 1000
   }
-});
+}); // All options: http://pouchdb.com/api.html#create_database
 
-// Log all db events 
+// Log all db events
 ['change', 'complete', 'uptodate', 'error', 'denied'].forEach(function(event) {
   db.on(event, function() {
     console.log('Pouch ' + event + '\'d', arguments);

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ var remote = new PouchDB('http://foo.iriscouch.com:5984', {
 ['change', 'complete', 'uptodate', 'error', 'denied'].forEach(function(event) {
   db.on(event, function() {
     console.log('Pouch ' + event + '\'d', arguments);
-  }
+  });
 });
 
 db.sync(remote, {live: true})
@@ -106,7 +106,7 @@ if (!config.remote_couch) {
 var db = new PouchDB(config.local_couch || 'local_couch');
 var remote = new PouchDB(config.remote_couch, {
   ajax: {
-    timeout: 20000
+    timeout: 6 * 1000
   }
 }); // All options: http://pouchdb.com/api.html#create_database
 ```


### PR DESCRIPTION
I removed the whole section on using PouchDB as a client to a CouchDB instance and as a local db because a developer will read this in the PouchDB documentation linked to in the installation. It was cluttery and confusing for me to read in two places, and it's shown in the last example anyway, which is retained.

Hopefully this helps other developers researching using Ember and Pouch together.