### PR TITLE
Enable coalesceFindRequests by default

### DIFF
--- a/lib/pouchdb-adapter.js
+++ b/lib/pouchdb-adapter.js
@@ -2,6 +2,8 @@ export default DS.RESTAdapter.extend({
 
   //db: new PouchDB('http://localhost:5984/ember-todo'),
 
+  coalesceFindRequests: true,
+
   init: function () {
     this._super();
 


### PR DESCRIPTION
`DS.Store` can attempt to combine multiple `find` calls from the same run loop into a single `findMany` call. This is enabled by default on `DS.Adapter`, but disabled by default on `DS.RESTAdapter` under the assumption that most REST APIs don't allow this type of request.

Since ember-pouch provides `#findMany`, it makes sense to enable this feature.

Refs:

* [DS.Adapter#coalesceFindRequests](http://emberjs.com/api/data/classes/DS.Adapter.html#property_coalesceFindRequests)
* [DS.RESTAdapter#coalesceFindRequests](http://emberjs.com/api/data/classes/DS.RESTAdapter.html#property_coalesceFindRequests)