### PR TITLE
Fix small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ var remote = new PouchDB('http://localhost:5984/my_couch');
 var db  = new PouchDB('local_couch');
 
 function doSync() {
-  local.sync(remote, {live: true})
+  db.sync(remote, {live: true})
     .on('error', function(err) {
       // Retry connection every 5 seconds
       setTimeout(doSync, 5000);


### PR DESCRIPTION
Looks like ref to `local` accidentally made it's way through during latest README edits.