### PR TITLE
Changes watcher improvements

### DIFF
--- a/lib/pouchdb-adapter.js
+++ b/lib/pouchdb-adapter.js
@@ -15,29 +15,31 @@ export default DS.RESTAdapter.extend({
       live: true,
       returnDocs: false
     }).on('change', function (change) {
-      var obj = this.db.rel.parseDocID(change.id);
-      // skip changes for non-relational_pouch docs. E.g., design docs.
-      if (!obj.type || !obj.id || obj.type === '') { return; }
+      Ember.run(function () {
+        var obj = this.db.rel.parseDocID(change.id);
+        // skip changes for non-relational_pouch docs. E.g., design docs.
+        if (!obj.type || !obj.id || obj.type === '') { return; }
 
-      var store = this.container.lookup('store:main');
+        var store = this.container.lookup('store:main');
 
-      var recordInStore = store.getById(obj.type, obj.id);
-      if (!recordInStore) {
-        // The record hasn't been loaded into the store; no need to reload its data.
-        return;
-      }
-      if (!recordInStore.get('isLoaded') || recordInStore.get('isDirty')) {
-        // The record either hasn't loaded yet or has unpersisted local changes.
-        // In either case, we don't want to refresh it in the store
-        // (and for some substates, attempting to do so will result in an error).
-        return;
-      }
+        var recordInStore = store.getById(obj.type, obj.id);
+        if (!recordInStore) {
+          // The record hasn't been loaded into the store; no need to reload its data.
+          return;
+        }
+        if (!recordInStore.get('isLoaded') || recordInStore.get('isDirty')) {
+          // The record either hasn't loaded yet or has unpersisted local changes.
+          // In either case, we don't want to refresh it in the store
+          // (and for some substates, attempting to do so will result in an error).
+          return;
+        }
 
-      if (change.deleted) {
-        store.unloadRecord(recordInStore);
-      } else {
-        recordInStore.reload();
-      }
+        if (change.deleted) {
+          store.unloadRecord(recordInStore);
+        } else {
+          recordInStore.reload();
+        }
+      }.bind(this));
     }.bind(this));
   },
 

--- a/lib/pouchdb-adapter.js
+++ b/lib/pouchdb-adapter.js
@@ -16,6 +16,9 @@ export default DS.RESTAdapter.extend({
       returnDocs: false
     }).on('change', function (change) {
       var obj = this.db.rel.parseDocID(change.id);
+      // skip changes for non-relational_pouch docs. E.g., design docs.
+      if (!obj.type || !obj.id || obj.type === '') { return; }
+
       var store = this.container.lookup('store:main');
 
       store.findAll(obj.type);

--- a/lib/pouchdb-adapter.js
+++ b/lib/pouchdb-adapter.js
@@ -21,11 +21,22 @@ export default DS.RESTAdapter.extend({
 
       var store = this.container.lookup('store:main');
 
-      store.findAll(obj.type);
+      var recordInStore = store.getById(obj.type, obj.id);
+      if (!recordInStore) {
+        // The record hasn't been loaded into the store; no need to reload its data.
+        return;
+      }
+      if (!recordInStore.get('isLoaded') || recordInStore.get('isDirty')) {
+        // The record either hasn't loaded yet or has unpersisted local changes.
+        // In either case, we don't want to refresh it in the store
+        // (and for some substates, attempting to do so will result in an error).
+        return;
+      }
 
       if (change.deleted) {
-        var rec = store.recordForId(obj.type, obj.id);
-        store.unloadRecord(rec);
+        store.unloadRecord(recordInStore);
+      } else {
+        recordInStore.reload();
       }
     }.bind(this));
   },

--- a/lib/pouchdb-adapter.js
+++ b/lib/pouchdb-adapter.js
@@ -16,6 +16,10 @@ export default DS.RESTAdapter.extend({
       returnDocs: false
     }).on('change', function (change) {
       Ember.run(function () {
+        // If relational_pouch isn't initialized yet, there can't be any records
+        // in the store to update.
+        if (!this.db.rel) { return; }
+
         var obj = this.db.rel.parseDocID(change.id);
         // skip changes for non-relational_pouch docs. E.g., design docs.
         if (!obj.type || !obj.id || obj.type === '') { return; }

--- a/lib/pouchdb-adapter.js
+++ b/lib/pouchdb-adapter.js
@@ -12,7 +12,8 @@ export default DS.RESTAdapter.extend({
   _startChangesToStoreListener: function () {
     this.changes = this.db.changes({
       since: 'now',
-      live: true
+      live: true,
+      returnDocs: false
     }).on('change', function (change) {
       var obj = this.db.rel.parseDocID(change.id);
       var store = this.container.lookup('store:main');

--- a/lib/pouchdb-adapter.js
+++ b/lib/pouchdb-adapter.js
@@ -6,8 +6,10 @@ export default DS.RESTAdapter.extend({
 
   init: function () {
     this._super();
+    this._startChangesToStoreListener();
+  },
 
-    // Update store on change events
+  _startChangesToStoreListener: function () {
     this.changes = this.db.changes({
       since: 'now',
       live: true


### PR DESCRIPTION
Style, error-avoidance, and performance fixes for the automatic changes watcher. There are details in the commits; at a high-level:

* Don't throw exceptions when there's a change to a design doc or other non-relational_pouch doc.
* Don't keep changes around in memory since the watcher doesn't need them.
* Don't load records into the store that aren't already there. This makes a huge speed and memory difference on large databases.

All of these changes were initially suggested & implemented by my colleague @moses.