### PR TITLE
filter ddocs explicitly

### DIFF
--- a/lib/pouchdb-adapter.js
+++ b/lib/pouchdb-adapter.js
@@ -18,11 +18,15 @@ export default DS.RESTAdapter.extend({
       Ember.run(function () {
         // If relational_pouch isn't initialized yet, there can't be any records
         // in the store to update.
-        if (!this.db.rel) { return; }
+        if (!this.db.rel) {
+          return;
+        }
 
         var obj = this.db.rel.parseDocID(change.id);
-        // skip changes for non-relational_pouch docs. E.g., design docs.
-        if (!obj.type || !obj.id || obj.type === '') { return; }
+        // skip changes for non-relational-pouch docs, e.g. design docs
+        if (/^_design\//.test(obj.id)) {
+          return;
+        }
 
         var store = this.container.lookup('store:main');
 


### PR DESCRIPTION
Follow-up to 05e09e7. I like to be explicit about
filtering design docs; there really shouldn't be any
other kinds of docs in the database that aren't relational-y.

Also moved `return`s to the next line, because I think it's
more consistent.