### PR TITLE
Do not attempt to apply changes for unknown models

### DIFF
--- a/lib/pouchdb-adapter.js
+++ b/lib/pouchdb-adapter.js
@@ -26,6 +26,14 @@ export default DS.RESTAdapter.extend({
 
         var store = this.container.lookup('store:main');
 
+        try {
+          store.modelFor(obj.type);
+        } catch (e) {
+          // The record refers to a model which this version of the application
+          // does not have.
+          return;
+        }
+
         var recordInStore = store.getById(obj.type, obj.id);
         if (!recordInStore) {
           // The record hasn't been loaded into the store; no need to reload its data.


### PR DESCRIPTION
Prevents an error in the event that a record's ID parses as a relational_pouch ID, but refers to a model which the running application does not have.

E.g., this might happen if you have an application that replicates from a CouchDB instance. As the application evolves, new models may be introduced and show up in the remote CouchDB instance. Clients are likely to have a span of time when they can see records for the new models, but have not yet updated to the newest code — particularly if the application is an offline webapp or a Cordova-based mobile app.