### PR TITLE
Use modelName instead of typeKey when available, but preserve existing ID generation behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,16 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
+  # After travis-ci/travis-ci#3225 is resolved, restore this and remove the
+  # manual download/install of PhantomJS 2.0.
+  # - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
+  - mkdir 'phantomjs-2.0.0'
+  - cd 'phantomjs-2.0.0'
+  - curl -O 'https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2'
+  - tar xjvf 'phantomjs-2.0.0-ubuntu-12.04.tar.bz2'
+  - cd -
+  - export PATH=./phantomjs-2.0.0:$PATH
+
   - "npm config set spin false"
   - "npm install -g npm@^2"
 

--- a/addon/adapters/pouch.js
+++ b/addon/adapters/pouch.js
@@ -133,8 +133,12 @@ export default DS.RESTAdapter.extend({
 
   _recordToData: function (store, type, record) {
     var data = {};
-    var recordTypeName = this.getRecordTypeName(type);
-    var serializer = store.serializerFor(recordTypeName);
+    // Though it would work to use the default recordTypeName for modelName &
+    // serializerKey here, these uses are conceptually distinct and may vary
+    // independently.
+    var modelName = type.modelName || type.typeKey;
+    var serializerKey = camelize(modelName);
+    var serializer = store.serializerFor(modelName);
 
     var recordToStore = record;
     // In Ember-Data beta.15, we need to take a snapshot. See issue #45.
@@ -152,7 +156,7 @@ export default DS.RESTAdapter.extend({
       {includeId: true}
     );
 
-    data = data[recordTypeName];
+    data = data[serializerKey];
 
     // ember sets it to null automatically. don't need it.
     if (data.rev === null) {

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -1,0 +1,13 @@
+import { Adapter } from 'ember-pouch/index';
+import PouchDB from 'pouchdb';
+
+function createDb() {
+  return new PouchDB('ember-pouch-test');
+}
+
+export default Adapter.extend({
+  init() {
+    this._super(...arguments);
+    this.set('db', createDb());
+  }
+});

--- a/tests/dummy/app/models/taco-soup.js
+++ b/tests/dummy/app/models/taco-soup.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  rev: DS.attr('string'),
+
+  flavor: DS.attr('string')
+});

--- a/tests/integration/adapters/pouch-test.js
+++ b/tests/integration/adapters/pouch-test.js
@@ -1,0 +1,165 @@
+import { module, test } from 'qunit';
+import startApp from '../../helpers/start-app';
+
+import Ember from 'ember';
+/* globals PouchDB */
+
+var App;
+
+/*
+ * Tests basic CRUD behavior for an app using the ember-pouch adapter.
+ */
+
+module('adapter:pouch [integration]', {
+  beforeEach: function (assert) {
+    var done = assert.async();
+
+    // TODO: do this in a way that doesn't require duplicating the name of the
+    // test database here and in dummy/app/adapters/application.js. Importing
+    // the adapter directly doesn't work because of what seems like a resolver
+    // issue.
+    (new PouchDB('ember-pouch-test')).destroy().then(() => {
+      App = startApp();
+      done();
+    });
+  },
+
+  afterEach: function (assert) {
+    Ember.run(App, 'destroy');
+  }
+});
+
+function db() {
+  return adapter().get('db');
+}
+
+function adapter() {
+  // the default adapter in the dummy app is an ember-pouch adapter
+  return App.__container__.lookup('adapter:application');
+}
+
+function store() {
+  return App.__container__.lookup('store:main');
+}
+
+test('can find all', function (assert) {
+  assert.expect(3);
+
+  var done = assert.async();
+  Ember.RSVP.Promise.resolve().then(() => {
+    return db().bulkDocs([
+      { _id: 'tacoSoup_2_A', data: { flavor: 'al pastor' } },
+      { _id: 'tacoSoup_2_B', data: { flavor: 'black bean' } },
+      { _id: 'burritoShake_2_X', data: { consistency: 'smooth' } }
+    ]);
+  }).then(() => {
+    return store().find('taco-soup');
+  }).then((found) => {
+    assert.equal(found.get('length'), 2, 'should have found the two taco soup items only');
+    assert.deepEqual(found.mapBy('id'), ['A', 'B'],
+      'should have extracted the IDs correctly');
+    assert.deepEqual(found.mapBy('flavor'), ['al pastor', 'black bean'],
+      'should have extracted the attributes also');
+    done();
+  }).catch((error) => {
+    console.error('error in test', error);
+    assert.ok(false, 'error in test:' + error);
+    done();
+  });
+});
+
+test('can find one', function (assert) {
+  assert.expect(2);
+
+  var done = assert.async();
+  Ember.RSVP.Promise.resolve().then(() => {
+    return db().bulkDocs([
+      { _id: 'tacoSoup_2_C', data: { flavor: 'al pastor' } },
+      { _id: 'tacoSoup_2_D', data: { flavor: 'black bean' } },
+    ]);
+  }).then(() => {
+    return store().find('taco-soup', 'D');
+  }).then((found) => {
+    assert.equal(found.get('id'), 'D',
+      'should have found the requested item');
+    assert.deepEqual(found.get('flavor'), 'black bean',
+      'should have extracted the attributes also');
+    done();
+  }).catch((error) => {
+    console.error('error in test', error);
+    assert.ok(false, 'error in test:' + error);
+    done();
+  });
+});
+
+test('create a new record', function (assert) {
+  assert.expect(1);
+
+  var done = assert.async();
+  Ember.RSVP.Promise.resolve().then(() => {
+    var newSoup = store().createRecord('taco-soup', { id: 'E', flavor: 'balsamic' });
+    return newSoup.save();
+  }).then((saved) => {
+    return db().get('tacoSoup_2_E');
+  }).then((newDoc) => {
+    assert.equal(newDoc.data.flavor, 'balsamic', 'should have saved the attribute');
+    done();
+  }).catch((error) => {
+    console.error('error in test', error);
+    assert.ok(false, 'error in test:' + error);
+    done();
+  });
+});
+
+test('update an existing record', function (assert) {
+  assert.expect(1);
+
+  var done = assert.async();
+  Ember.RSVP.Promise.resolve().then(() => {
+    return db().bulkDocs([
+      { _id: 'tacoSoup_2_C', data: { flavor: 'al pastor' } },
+      { _id: 'tacoSoup_2_D', data: { flavor: 'black bean' } },
+    ]);
+  }).then(() => {
+    return store().find('taco-soup', 'C');
+  }).then((found) => {
+    found.set('flavor', 'pork');
+    return found.save();
+  }).then((saved) => {
+    return db().get('tacoSoup_2_C');
+  }).then((updatedDoc) => {
+    assert.equal(updatedDoc.data.flavor, 'pork', 'should have updated the attribute');
+    done();
+  }).catch((error) => {
+    console.error('error in test', error);
+    assert.ok(false, 'error in test:' + error);
+    done();
+  });
+});
+
+test('delete an existing record', function (assert) {
+  assert.expect(1);
+
+  var done = assert.async();
+  Ember.RSVP.Promise.resolve().then(() => {
+    return db().bulkDocs([
+      { _id: 'tacoSoup_2_C', data: { flavor: 'al pastor' } },
+      { _id: 'tacoSoup_2_D', data: { flavor: 'black bean' } },
+    ]);
+  }).then(() => {
+    return store().find('taco-soup', 'C');
+  }).then((found) => {
+    return found.destroyRecord();
+  }).then(() => {
+    return db().get('tacoSoup_2_C');
+  }).then((doc) => {
+    assert.ok(!doc, 'document should no longer exist');
+  }, (result) => {
+    assert.equal(result.status, 404, 'document should no longer exist');
+    done();
+  }).catch((error) => {
+    console.error('error in test', error);
+    assert.ok(false, 'error in test:' + error);
+    done();
+  });
+});


### PR DESCRIPTION
This is my suggestion for #62, based on my desire to prevent all existing ember-pouch users from having to do a data migration as discussed in #63.

It also includes a set of very basic integration tests. If this feature doesn't get integrated, they should still be usable on their own. (I wrote them to verify that this change did preserve the prior behavior.)