### PR TITLE
Missed one use of typeKey in #64.

### DIFF
--- a/addon/adapters/pouch.js
+++ b/addon/adapters/pouch.js
@@ -118,7 +118,7 @@ export default DS.RESTAdapter.extend({
       }
       var relDef = {};
       relDef[rel.kind] = {
-        type: rel.type.typeKey,
+        type: recordTypeName,
         options: rel.options
       };
       if (!schemaDef.relations) {

--- a/tests/dummy/app/models/food-item.js
+++ b/tests/dummy/app/models/food-item.js
@@ -1,8 +1,9 @@
 import DS from 'ember-data';
 
+// N.b.: awkward model name is to test getRecordTypeName
+
 export default DS.Model.extend({
   rev: DS.attr('string'),
 
-  flavor: DS.attr('string'),
-  ingredients: DS.hasMany('food-item', { async: true })
+  name: DS.attr('string')
 });

--- a/tests/integration/adapters/pouch-test.js
+++ b/tests/integration/adapters/pouch-test.js
@@ -92,6 +92,37 @@ test('can find one', function (assert) {
   });
 });
 
+test('can find associated records', function (assert) {
+  assert.expect(3);
+
+  var done = assert.async();
+  Ember.RSVP.Promise.resolve().then(() => {
+    return db().bulkDocs([
+      { _id: 'tacoSoup_2_C', data: { flavor: 'al pastor', ingredients: ['X', 'Y'] } },
+      { _id: 'tacoSoup_2_D', data: { flavor: 'black bean', ingredients: ['Z'] } },
+      { _id: 'foodItem_2_X', data: { name: 'pineapple' }},
+      { _id: 'foodItem_2_Y', data: { name: 'pork loin' }},
+      { _id: 'foodItem_2_Z', data: { name: 'black beans' }}
+    ]);
+  }).then(() => {
+    return store().find('taco-soup', 'C');
+  }).then((found) => {
+    assert.equal(found.get('id'), 'C',
+      'should have found the requested item');
+    return found.get('ingredients');
+  }).then((foundIngredients) => {
+    assert.deepEqual(foundIngredients.mapBy('id'), ['X', 'Y'],
+      'should have found both associated items');
+    assert.deepEqual(foundIngredients.mapBy('name'), ['pineapple', 'pork loin'],
+      'should have fully loaded the associated items');
+    done();
+  }).catch((error) => {
+    console.error('error in test', error);
+    assert.ok(false, 'error in test:' + error);
+    done();
+  });
+});
+
 test('create a new record', function (assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Not ready to merge, because the new test does not pass on ember-data 1.0-beta19 or 19.1. The problem appears to be that the relationship returned by eachRelationship has the name of the associated type as `type` instead of the DS.Model object. It works fine on older versions (tested beta17 and 18).

Have not tried in a real app yet to see if this is a test artifact or an ember-data bug.