### PR TITLE
Ember-try config for all supported versions of ember-data, plus fixes for the tests on ember-data beta19 and later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,11 @@ cache:
     - node_modules
 
 env:
-  - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-data-beta.15
+  - EMBER_TRY_SCENARIO=ember-data-beta.16
+  - EMBER_TRY_SCENARIO=ember-data-beta.18
+  - EMBER_TRY_SCENARIO=ember-data-beta.19
+  - EMBER_TRY_SCENARIO=ember-data-1.13
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
@@ -18,6 +22,8 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-release
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:

--- a/bower.json
+++ b/bower.json
@@ -22,10 +22,10 @@
     "tests"
   ],
   "dependencies": {
-    "ember": "1.12.0",
+    "ember": "^1.10.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "~1.0.0-beta.12",
+    "ember-data": "~1.0.0-beta.15",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,53 +1,53 @@
 module.exports = {
   scenarios: [
     {
-      name: 'default',
+      name: 'ember-data-beta.15',
       dependencies: {
-        'ember': 'components/ember#release',
-        'ember-data': '1.0.0-beta.17'
+        'ember': '1.10.0',
+        'ember-data': '1.0.0-beta.15'
       },
       resolutions: {
-        'ember': 'release'
+        'ember': '1.10.0'
       }
     },
     {
-      name: 'legacy ember-data 1.0.0.beta.12',
+      name: 'ember-data-beta.16',
       dependencies: {
-        'ember': 'components/ember#release',
-        'ember-data': 'components/ember-data#1.0.0-beta.12'
+        'ember': '1.10.0',
+        'ember-data': '1.0.0-beta.16.1'
       },
       resolutions: {
-        'ember': 'release'
+        'ember': '1.10.0'
       }
     },
     {
-      name: 'legacy ember-data 1.0.0.beta.14.1',
+      name: 'ember-data-beta.18',
       dependencies: {
-        'ember': 'components/ember#release',
-        'ember-data': 'components/ember-data#1.0.0-beta.14.1'
+        'ember': '1.12.1',
+        'ember-data': '1.0.0-beta.18'
       },
       resolutions: {
-        'ember': 'release'
+        'ember': '1.12.1'
       }
     },
     {
-      name: 'legacy ember-data 1.0.0.beta.15',
+      name: 'ember-data-beta.19',
       dependencies: {
-        'ember': 'components/ember#release',
-        'ember-data': 'components/ember-data#1.0.0-beta.15'
+        'ember': '1.13.2',
+        'ember-data': '1.0.0-beta.19.2'
       },
       resolutions: {
-        'ember': 'release'
+        'ember': '1.13.2'
       }
     },
     {
-      name: 'legacy ember-data 1.0.0.beta.16.1',
+      name: 'ember-data-1.13',
       dependencies: {
-        'ember': 'components/ember#release',
-        'ember-data': 'components/ember-data#1.0.0-beta.16.1'
+        'ember': '1.13.2',
+        'ember-data': '1.13.2'
       },
       resolutions: {
-        'ember': 'release'
+        'ember': '1.13.2'
       }
     },
     {

--- a/tests/integration/adapters/pouch-test.js
+++ b/tests/integration/adapters/pouch-test.js
@@ -20,6 +20,17 @@ module('adapter:pouch [integration]', {
     // issue.
     (new PouchDB('ember-pouch-test')).destroy().then(() => {
       App = startApp();
+      var bootPromise;
+      Ember.run(() => {
+        if (App.boot) {
+          App.advanceReadiness();
+          bootPromise = App.boot();
+        } else {
+          bootPromise = Ember.RSVP.Promise.resolve();
+        }
+      });
+      return bootPromise;
+    }).then(() => {
       done();
     });
   },


### PR DESCRIPTION
There is code in place to support versions back to beta.15, so it seems like we should have the tests run that far back. We can always drop support in the future.

Each ember-data version is paired with the latest bugfix of the ember version that was current when that ember-data version was released.

This PR also makes it so that a failure in one of the symbolic versions (release, beta, canary) does not make the whole build a failure. Rationale: If there’s an incompatibility between a future version of ember or ember-data and ember-pouch, that should be fixed. But it shouldn’t block accepting changes that do pass on all the supported versions. (If there were a way to have travis run a separate build whenever there was a new release/beta/canary version, that would be great. But I don't think there is.)

This PR also fixes an incompatibility between the existing integration tests and ember-data beta19.