### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ And of course thanks to all our wonderful contributors, [here](https://github.co
 
 ## Changelog
 
-* **2.0.1** - Fixed #62 (deprecated `typekey` in Ember-Data 1.0.0-beta.18)
-* **2.0.0** - Ember CLI support, due to some amazing support by @fsmanuel! Bower and npm support are deprecated now; you are recommended to use Ember CLI instead.
+* **2.0.1** - Fixed [#62](https://github.com/nolanlawson/ember-pouch/issues/62) thanks to [@rsutphin](https://github.com/rsutphin) (deprecated `typekey` in Ember-Data 1.0.0-beta.18)
+* **2.0.0** - Ember CLI support, due to some amazing support by [@fsmanuel](https://github.com/fsmanuel)! Bower and npm support are deprecated now; you are recommended to use Ember CLI instead.
 * **1.2.5** - Last release with regular Bower/npm support via bundle javascript in the `dist/` directory.
 * **1.0.0** - First release


### PR DESCRIPTION
Remove reference to typkey as it was deprecated, unless you want to leave for reference for older versions of ember-data.