### PR TITLE
Add Ember Data 2.0 Reload behavior

### DIFF
--- a/addon/adapters/pouch.js
+++ b/addon/adapters/pouch.js
@@ -20,6 +20,12 @@ const {
 export default DS.RESTAdapter.extend({
   coalesceFindRequests: true,
 
+  // Ember Data 2.0 Reload behavior
+  shouldReloadRecord: function() { return true; },
+  shouldReloadAll: function() { return true; },
+  shouldBackgroundReloadRecord: function() { return true; },
+  shouldBackgroundReloadAll: function() { return true; },
+
   _startChangesToStoreListener: on('init', function () {
     this.changes = this.db.changes({
       since: 'now',


### PR DESCRIPTION
This fixes the https://github.com/nolanlawson/ember-pouch/issues/79 deprecation warning and preserves the current behavior until we know the new Reload behavior works and is faster in Ember Data 2.0