### PR TITLE
Change access to db property to use Ember.get

### DIFF
--- a/addon/adapters/pouch.js
+++ b/addon/adapters/pouch.js
@@ -27,7 +27,7 @@ export default DS.RESTAdapter.extend({
   shouldBackgroundReloadRecord: function () { return false; },
 
   _startChangesToStoreListener: on('init', function () {
-    this.changes = this.db.changes({
+    this.changes = this.get('db').changes({
       since: 'now',
       live: true,
       returnDocs: false
@@ -37,9 +37,9 @@ export default DS.RESTAdapter.extend({
   onChange: function (change) {
     // If relational_pouch isn't initialized yet, there can't be any records
     // in the store to update.
-    if (!this.db.rel) { return; }
+    if (!this.get('db').rel) { return; }
 
-    var obj = this.db.rel.parseDocID(change.id);
+    var obj = this.get('db').rel.parseDocID(change.id);
     // skip changes for non-relational_pouch docs. E.g., design docs.
     if (!obj.type || !obj.id || obj.type === '') { return; }
 
@@ -81,7 +81,7 @@ export default DS.RESTAdapter.extend({
   _init: function (store, type) {
     var self = this,
         recordTypeName = this.getRecordTypeName(type);
-    if (!this.db || typeof this.db !== 'object') {
+    if (!this.get('db') || typeof this.get('db') !== 'object') {
       throw new Error('Please set the `db` property on the adapter.');
     }
 
@@ -139,7 +139,7 @@ export default DS.RESTAdapter.extend({
       }
     });
 
-    this.db.setSchema(this._schema);
+    this.get('db').setSchema(this._schema);
   },
 
   _recordToData: function (store, type, record) {
@@ -202,12 +202,12 @@ export default DS.RESTAdapter.extend({
   findAll: function(store, type /*, sinceToken */) {
     // TODO: use sinceToken
     this._init(store, type);
-    return this.db.rel.find(this.getRecordTypeName(type));
+    return this.get('db').rel.find(this.getRecordTypeName(type));
   },
 
   findMany: function(store, type, ids) {
     this._init(store, type);
-    return this.db.rel.find(this.getRecordTypeName(type), ids);
+    return this.get('db').rel.find(this.getRecordTypeName(type), ids);
   },
 
   findQuery: function(/* store, type, query */) {
@@ -230,7 +230,7 @@ export default DS.RESTAdapter.extend({
   findRecord: function (store, type, id) {
     this._init(store, type);
     var recordTypeName = this.getRecordTypeName(type);
-    return this.db.rel.find(recordTypeName, id).then(function (payload) {
+    return this.get('db').rel.find(recordTypeName, id).then(function (payload) {
       // Ember Data chokes on empty payload, this function throws
       // an error when the requested data is not found
       if (typeof payload === 'object' && payload !== null) {
@@ -250,19 +250,19 @@ export default DS.RESTAdapter.extend({
   createRecord: function(store, type, record) {
     this._init(store, type);
     var data = this._recordToData(store, type, record);
-    return this.db.rel.save(this.getRecordTypeName(type), data);
+    return this.get('db').rel.save(this.getRecordTypeName(type), data);
   },
 
   updateRecord: function (store, type, record) {
     this._init(store, type);
     var data = this._recordToData(store, type, record);
-    return this.db.rel.save(this.getRecordTypeName(type), data);
+    return this.get('db').rel.save(this.getRecordTypeName(type), data);
   },
 
   deleteRecord: function (store, type, record) {
     this._init(store, type);
     var data = this._recordToData(store, type, record);
-    return this.db.rel.del(this.getRecordTypeName(type), data)
+    return this.get('db').rel.del(this.getRecordTypeName(type), data)
       .then(extractDeleteRecord);
   }
 });


### PR DESCRIPTION
Right now in the ember adapter, the code is using this.db to reference the PouchDB used.  For most use cases this works fine, but it doesn't work if you are trying to set the db via injection doing something like this:
```javascript
var configDB = new PouchDB('config');
application.register('pouchdb:configdb', configDB, {instantiate: false});
application.inject('adapter', 'db', 'pouchdb:configdb');  
```
In the example above this.db will be undefined, but this.get('db') will return the defined PouchDB.

This pull request simply changes the this.db references to this.get('db') so that the PouchDB can be injected or can be used the way it is defined in the readme.
