### PR TITLE
remove deprecation warnings for 1.13

### DIFF
--- a/addon/adapters/pouch.js
+++ b/addon/adapters/pouch.js
@@ -43,7 +43,7 @@ export default DS.RESTAdapter.extend({
     // skip changes for non-relational_pouch docs. E.g., design docs.
     if (!obj.type || !obj.id || obj.type === '') { return; }
 
-    var store = this.container.lookup('store:main');
+    var store = this.store;
 
     try {
       store.modelFor(obj.type);
@@ -53,12 +53,12 @@ export default DS.RESTAdapter.extend({
       return;
     }
 
-    var recordInStore = store.getById(obj.type, obj.id);
+    var recordInStore = store.peekRecord(obj.type, obj.id);
     if (!recordInStore) {
       // The record hasn't been loaded into the store; no need to reload its data.
       return;
     }
-    if (!recordInStore.get('isLoaded') || recordInStore.get('isDirty')) {
+    if (!recordInStore.get('isLoaded') || recordInStore.get('hasDirtyAttributes')) {
       // The record either hasn't loaded yet or has unpersisted local changes.
       // In either case, we don't want to refresh it in the store
       // (and for some substates, attempting to do so will result in an error).

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "ember": "^1.10.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "~1.0.0-beta.15",
+    "ember-data": "~1.13.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",

--- a/tests/integration/adapters/pouch-test.js
+++ b/tests/integration/adapters/pouch-test.js
@@ -50,7 +50,7 @@ function adapter() {
 }
 
 function store() {
-  return App.__container__.lookup('store:main');
+  return App.__container__.lookup('service:store');
 }
 
 test('can find all', function (assert) {
@@ -64,7 +64,7 @@ test('can find all', function (assert) {
       { _id: 'burritoShake_2_X', data: { consistency: 'smooth' } }
     ]);
   }).then(() => {
-    return store().find('taco-soup');
+    return store().findAll('taco-soup');
   }).then((found) => {
     assert.equal(found.get('length'), 2, 'should have found the two taco soup items only');
     assert.deepEqual(found.mapBy('id'), ['A', 'B'],
@@ -146,7 +146,7 @@ test('create a new record', function (assert) {
   }).then((newDoc) => {
     assert.equal(newDoc.data.flavor, 'balsamic', 'should have saved the attribute');
 
-    var recordInStore = store().getById('tacoSoup', 'E');
+    var recordInStore = store().peekRecord('tacoSoup', 'E');
     assert.equal(newDoc._rev, recordInStore.get('rev'),
       'should have associated the ember-data record with the rev for the new record');
 
@@ -177,7 +177,7 @@ test('update an existing record', function (assert) {
   }).then((updatedDoc) => {
     assert.equal(updatedDoc.data.flavor, 'pork', 'should have updated the attribute');
 
-    var recordInStore = store().getById('tacoSoup', 'C');
+    var recordInStore = store().peekRecord('tacoSoup', 'C');
     assert.equal(updatedDoc._rev, recordInStore.get('rev'),
       'should have associated the ember-data record with the updated rev');
 


### PR DESCRIPTION
fixes #78

This change will be incompatible with the betas of Ember Data, just fyi. Users will have to upgrade Ember Data as well.