### PR TITLE
`Attachment` transform, with `attachment.stub: true` support and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,39 @@ PouchDB.debug.enable('*');
 
 See the [PouchDB sync API](http://pouchdb.com/api.html#sync) for full usage instructions.
 
+## Attachments
+
+`Ember-Pouch` provides an `attachment` transform for your models, which makes working with attachments is as simple as working with any other field.
+
+Add a `DS.attr('attachment')` field to your model:
+
+```js
+// myapp/models/photo-album.js
+export default DS.Model.extend({
+  photos: DS.attr('attachment');
+});
+```
+
+Here, instances of `PhotoAlbum` have a `photos` field, which is an array of plain `Ember.Object`s, which have a `.name` and `.content_type`. Non-stubbed attachment also have a `.data` field; and stubbed attachments have a `.stub` instead.
+```handlebars
+<ul>
+  {{#each myalbum.photos as |photo|}}
+    <li>{{photo.name}}</li>
+  {{/each}}
+</ul>
+```
+
+Attach new files by adding an `Ember.Object` with a `.name`, `.content_type` and `.data` to array of attachments. 
+
+```js
+// somewhere in your controller/component:
+myAlbum.get('photos').addObject(Ember.Object.create({
+  'name': 'kitten.jpg',
+  'content_type': 'image/jpg',
+  'data': data // ... can be a DOM File, Blob, or plain old String
+}));
+```
+
 ## Sample app
 
 Tom Dale's blog example using Ember CLI and EmberPouch: [broerse/ember-cli-blog](https://github.com/broerse/ember-cli-blog)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Attach new files by adding an `Ember.Object` with a `.name`, `.content_type` and
 myAlbum.get('photos').addObject(Ember.Object.create({
   'name': 'kitten.jpg',
   'content_type': 'image/jpg',
-  'data': data // ... can be a DOM File, Blob, or plain old String
+  'data': btoa('hello world') // base64-encoded `String`, or a DOM `Blob`, or a `File`
 }));
 ```
 

--- a/addon/transforms/attachment.js
+++ b/addon/transforms/attachment.js
@@ -1,0 +1,37 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+
+const { isNone } = Ember;
+const keys = Object.keys || Ember.keys;
+
+export default DS.Transform.extend({
+  deserialize: function(serialized) {
+    if (isNone(serialized)) { return null; }
+
+    return keys(serialized).map(function (attachmentName) {
+      return Ember.Object.create({
+        name: attachmentName,
+        content_type: serialized[attachmentName]['content_type'],
+        data: serialized[attachmentName]['data'],
+        stub: serialized[attachmentName]['stub'],
+      });
+    });
+  },
+
+  serialize: function(deserialized) {
+    if (!Ember.isArray(deserialized)) { return null; }
+
+    return deserialized.reduce(function (acc, attachment) {
+      const serialized = {
+        content_type: attachment.get('content_type'),
+      };
+      if (attachment.get('stub')) {
+        serialized.stub = true;
+      } else {
+        serialized.data = attachment.get('data');
+      }
+      acc[attachment.get('name')] = serialized;
+      return acc;
+    }, {});
+  }
+});

--- a/app/transforms/attachment.js
+++ b/app/transforms/attachment.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-pouch/transforms/attachment';

--- a/tests/unit/transforms/attachment-test.js
+++ b/tests/unit/transforms/attachment-test.js
@@ -6,6 +6,10 @@ let testSerializedData = {
   'test.txt': {
     content_type: 'text/plain',
     data: 'hello world!'
+  },
+  'stub.json': {
+    stub: true,
+    content_type: 'application/json'
   }
 };
 
@@ -14,6 +18,11 @@ let testDeserializedData = [
     name: 'test.txt',
     content_type: 'text/plain',
     data: 'hello world!'
+  }),
+  Ember.Object.create({
+    name: 'stub.json',
+    content_type: 'application/json',
+    stub: true
   })
 ];
 
@@ -25,10 +34,15 @@ test('it serializes an attachment', function(assert) {
   assert.equal(transform.serialize(undefined), null);
 
   let serializedData = transform.serialize(testDeserializedData);
-  let name = testDeserializedData[0].name;
+  let name = testDeserializedData[0].get('name');
 
   assert.equal(serializedData[name].content_type, testSerializedData[name].content_type);
   assert.equal(serializedData[name].data, testSerializedData[name].data);
+
+  let stub = testDeserializedData[1].get('name');
+
+  assert.equal(serializedData[stub].content_type, testSerializedData[stub].content_type);
+  assert.equal(serializedData[stub].stub, true);
 });
 
 test('it deserializes an attachment', function(assert) {
@@ -41,4 +55,8 @@ test('it deserializes an attachment', function(assert) {
   assert.equal(deserializedData[0].get('name'), testDeserializedData[0].get('name'));
   assert.equal(deserializedData[0].get('content_type'), testDeserializedData[0].get('content_type'));
   assert.equal(deserializedData[0].get('data'), testDeserializedData[0].get('data'));
+
+  assert.equal(deserializedData[1].get('name'), testDeserializedData[1].get('name'));
+  assert.equal(deserializedData[1].get('content_type'), testDeserializedData[1].get('content_type'));
+  assert.equal(deserializedData[1].get('stub'), true);
 });

--- a/tests/unit/transforms/attachment-test.js
+++ b/tests/unit/transforms/attachment-test.js
@@ -1,0 +1,44 @@
+import { moduleFor, test } from 'ember-qunit';
+
+import Ember from 'ember';
+
+let testSerializedData = {
+  'test.txt': {
+    content_type: 'text/plain',
+    data: 'hello world!'
+  }
+};
+
+let testDeserializedData = [
+  Ember.Object.create({
+    name: 'test.txt',
+    content_type: 'text/plain',
+    data: 'hello world!'
+  })
+];
+
+moduleFor('transform:attachment', 'Unit | Transform | attachment', {});
+
+test('it serializes an attachment', function(assert) {
+  let transform = this.subject();
+  assert.equal(transform.serialize(null), null);
+  assert.equal(transform.serialize(undefined), null);
+
+  let serializedData = transform.serialize(testDeserializedData);
+  let name = testDeserializedData[0].name;
+
+  assert.equal(serializedData[name].content_type, testSerializedData[name].content_type);
+  assert.equal(serializedData[name].data, testSerializedData[name].data);
+});
+
+test('it deserializes an attachment', function(assert) {
+  let transform = this.subject();
+  assert.equal(transform.deserialize(null), null);
+  assert.equal(transform.deserialize(undefined), null);
+
+  let deserializedData = transform.deserialize(testSerializedData);
+
+  assert.equal(deserializedData[0].get('name'), testDeserializedData[0].get('name'));
+  assert.equal(deserializedData[0].get('content_type'), testDeserializedData[0].get('content_type'));
+  assert.equal(deserializedData[0].get('data'), testDeserializedData[0].get('data'));
+});


### PR DESCRIPTION
As promised in #92, finally.