### PR TITLE
Added blueprint for pouch-model

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ PouchDB.debug.enable('*');
 
 See the [PouchDB sync API](http://pouchdb.com/api.html#sync) for full usage instructions.
 
+## EmberPouch Blueprints
+
+### Model
+
+In order to create a model run the following command from the command line:
+
+```
+ember g pouch-model <model-name>
+```
+
+Replace `<model-name>` with the name of your model and the file will automatically be generated for you.
+
 ## Sample app
 
 Tom Dale's blog example using Ember CLI and EmberPouch: [broerse/ember-cli-blog](https://github.com/broerse/ember-cli-blog)

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/pouch-model/files/__root__/__path__/__name__.js
+++ b/blueprints/pouch-model/files/__root__/__path__/__name__.js
@@ -1,0 +1,12 @@
+import Model from 'ember-pouch/model';
+import DS from 'ember-data';
+
+const {
+  attr,
+  hasMany,
+  belongsTo
+} = DS;
+
+export default Model.extend({
+  <%= attrs %>
+});

--- a/blueprints/pouch-model/index.js
+++ b/blueprints/pouch-model/index.js
@@ -1,0 +1,3 @@
+var EmberCliModelBlueprint = require('ember-cli/blueprints/model');
+
+module.exports = EmberCliModelBlueprint;


### PR DESCRIPTION
This replaces https://github.com/nolanlawson/ember-pouch/pull/90

It creates a blueprint to easily create model files that import from `ember-pouch/model`

usage: `ember g pouch-model <model-name>`