### PR TITLE
Make adapter call a hook when encountering a change for a record that is not yet loaded.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,17 @@ Out of the box, ember-pouch includes a PouchDB [change listener](http://pouchdb.
 
 However, ember-pouch does not automatically load new records that arrive during a sync. The records are saved in the local database, but **ember-data is not told to load them into memory**. Automatically loading every new record works well with a small number of records and a limited number of models. As an app grows, automatically loading every record will negatively impact app responsiveness during syncs (especially the first sync). To avoid puzzling slowdowns, ember-pouch only automatically reloads records you have already used ember-data to load.
 
-If you have a model or two that you know will always have a small number of records, you can write your own change listener to tell ember-data to automatically load them into memory as they arrive.
+If you have a model or two that you know will always have a small number of records, you can tell ember-data to automatically load them into memory as they arrive. Your PouchAdapter subclass has a method `unloadedDocumentChanged`, which is called when a document is received during sync that has not been loaded into the ember-data store. In your subclass, you can implement the following to load it automatically:
+
+```js
+  unloadedDocumentChanged: function(obj) {
+    let store = this.get('store');
+    let recordTypeName = this.getRecordTypeName(store.modelFor(obj.type));
+    this.get('db').rel.find(recordTypeName, obj.id).then(function(doc) {
+      store.pushPayload(recordTypeName, doc);
+    });
+  },
+```
 
 ### Plugins
 
@@ -238,7 +248,7 @@ function changeProjectDatabase(dbName, dbUser, dbPassword) {
       // this is where we told the adapter to change the current database.
       adapter.changeDb(db);
     }
-  )    
+  )
 }
 ```
 

--- a/addon/adapters/pouch.js
+++ b/addon/adapters/pouch.js
@@ -76,6 +76,7 @@ export default DS.RESTAdapter.extend({
     var recordInStore = store.peekRecord(obj.type, obj.id);
     if (!recordInStore) {
       // The record hasn't been loaded into the store; no need to reload its data.
+      this.unloadedDocumentChanged(obj);
       return;
     }
     if (!recordInStore.get('isLoaded') || recordInStore.get('hasDirtyAttributes')) {
@@ -90,6 +91,19 @@ export default DS.RESTAdapter.extend({
     } else {
       recordInStore.reload();
     }
+  },
+
+  unloadedDocumentChanged: function(/* obj */) {
+    /*
+     * For performance purposes, we don't load records into the store that haven't previously been loaded.
+     * If you want to change this, subclass this method, and push the data into the store. e.g.
+     *
+     *  let store = this.get('store');
+     *  let recordTypeName = this.getRecordTypeName(store.modelFor(obj.type));
+     *  this.get('db').rel.find(recordTypeName, obj.id).then(function(doc){
+     *    store.pushPayload(recordTypeName, doc);
+     *  });
+     */
   },
 
   willDestroy: function() {

--- a/tests/dummy/app/adapters/taco-salad.js
+++ b/tests/dummy/app/adapters/taco-salad.js
@@ -1,0 +1,39 @@
+import { Adapter } from 'ember-pouch/index';
+import PouchDB from 'pouchdb';
+import config from 'dummy/config/environment';
+import Ember from 'ember';
+
+const { assert, isEmpty } = Ember;
+
+function createDb() {
+  let localDb = config.emberpouch.localDb;
+
+  assert('emberpouch.localDb must be set', !isEmpty(localDb));
+
+  let db = new PouchDB(localDb);
+
+  if (config.emberpouch.remote) {
+      let remoteDb = new PouchDB(config.emberpouch.remoteDb);
+
+      db.sync(remoteDb, {
+        live: true,
+        retry: true
+      });
+  }
+
+  return db;
+}
+
+export default Adapter.extend({
+  init() {
+    this._super(...arguments);
+    this.set('db', createDb());
+  },
+  unloadedDocumentChanged(obj) {
+    let store = this.get('store');
+    let recordTypeName = this.getRecordTypeName(store.modelFor(obj.type));
+    this.get('db').rel.find(recordTypeName, obj.id).then(function(doc){
+      store.pushPayload(recordTypeName, doc);
+    });
+  }
+});

--- a/tests/dummy/app/models/taco-salad.js
+++ b/tests/dummy/app/models/taco-salad.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  rev: DS.attr('string'),
+
+  flavor: DS.attr('string'),
+  ingredients: DS.hasMany('food-item', { async: true })
+});


### PR DESCRIPTION
Pouch adapter now calls a hook method when encountering a change for a record that is not yet loaded.

- The hook is no-op by default, to match present behavior and performance profile
- Added a test demonstrating use of the hook to load the new data into the ember-data store

@lukemelia / @chrislopresto