### PR TITLE
Add override so serialiser saves hasMany

### DIFF
--- a/addon/serializers/pouch.js
+++ b/addon/serializers/pouch.js
@@ -1,3 +1,19 @@
 import DS from 'ember-data';
 
-export default DS.RESTSerializer.extend({});
+export default DS.RESTSerializer.extend({
+  _shouldSerializeHasMany: function() {
+    return true;
+  },
+
+  // This fixes a failure in Ember Data 1.13 where an empty hasMany
+  // was saving as undefined rather than [].
+  serializeHasMany(snapshot, json, relationship) {
+    this._super.apply(this, arguments);
+
+    const key = relationship.key;
+
+    if (!json[key]) {
+      json[key] = [];
+    }
+  }
+});

--- a/tests/dummy/app/models/food-item.js
+++ b/tests/dummy/app/models/food-item.js
@@ -5,5 +5,6 @@ import DS from 'ember-data';
 export default DS.Model.extend({
   rev: DS.attr('string'),
 
-  name: DS.attr('string')
+  name: DS.attr('string'),
+  soup: DS.belongsTo('taco-soup', { async: true })
 });

--- a/tests/dummy/app/serializers/application.js
+++ b/tests/dummy/app/serializers/application.js
@@ -1,0 +1,3 @@
+import { Serializer } from 'ember-pouch';
+
+export default Serializer;


### PR DESCRIPTION
As suggested [here](https://github.com/nolanlawson/ember-pouch/issues/16#issuecomment-122651303) by @fsmanuel.

What I missed in my [previous pull request](https://github.com/nolanlawson/ember-pouch/pull/109) was that the dummy application wasn’t using the PouchDB serialiser!