### PR TITLE
Correct import of Ember Data model blueprint

### DIFF
--- a/blueprints/pouch-model/index.js
+++ b/blueprints/pouch-model/index.js
@@ -1,3 +1,9 @@
-var EmberCliModelBlueprint = require('ember-cli/blueprints/model');
+var ModelBlueprint;
 
-module.exports = EmberCliModelBlueprint;
+try {
+  ModelBlueprint = require('ember-data/blueprints/model');
+} catch (e) {
+  ModelBlueprint = require('ember-cli/blueprints/model');
+}
+
+module.exports = ModelBlueprint;


### PR DESCRIPTION
As [suggested by @fsmanuel](https://github.com/nolanlawson/ember-pouch/issues/128#issuecomment-227289620), this fixes [@fredguth’s error generating a model](https://github.com/nolanlawson/ember-pouch/issues/128#issuecomment-227278998).

I’m not sure how this fix should affect the version number. Or maybe some kind of dual import should happen, to keep backward compatibility. Thoughts?

For now, @fredguth, you could just edit `node_modules/ember-pouch/blueprints/pouch-model/index.js` with this change and you’d be able to generate the model.