### PR TITLE
Attachments transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,39 @@ export default Ember.Route.extend({
     }
   }
 });
+```
 
+## Attachments
+
+`Ember-Pouch` provides an `attachment` transform for your models, which makes working with attachments is as simple as working with any other field.
+
+Add a `DS.attr('attachment')` field to your model:
+
+```js
+// myapp/models/photo-album.js
+export default DS.Model.extend({
+  photos: DS.attr('attachment');
+});
+```
+
+Here, instances of `PhotoAlbum` have a `photos` field, which is an array of plain `Ember.Object`s, which have a `.name` and `.content_type`. Non-stubbed attachment also have a `.data` field; and stubbed attachments have a `.stub` instead.
+```handlebars
+<ul>
+  {{#each myalbum.photos as |photo|}}
+    <li>{{photo.name}}</li>
+  {{/each}}
+</ul>
+```
+
+Attach new files by adding an `Ember.Object` with a `.name`, `.content_type` and `.data` to array of attachments. 
+
+```js
+// somewhere in your controller/component:
+myAlbum.get('photos').addObject(Ember.Object.create({
+  'name': 'kitten.jpg',
+  'content_type': 'image/jpg',
+  'data': data // ... can be a DOM File, Blob, or plain old String
+}));
 ```
 
 ## Sample app

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Attach new files by adding an `Ember.Object` with a `.name`, `.content_type` and
 myAlbum.get('photos').addObject(Ember.Object.create({
   'name': 'kitten.jpg',
   'content_type': 'image/jpg',
-  'data': data // ... can be a DOM File, Blob, or plain old String
+  'data': btoa('hello world') // base64-encoded `String`, or a DOM `Blob`, or a `File`
 }));
 ```
 

--- a/README.md
+++ b/README.md
@@ -186,12 +186,16 @@ export default Ember.Route.extend({
 
 `Ember-Pouch` provides an `attachment` transform for your models, which makes working with attachments as simple as working with any other field.
 
-Add a `DS.attr('attachment')` field to your model:
+Add a `DS.attr('attachment')` field to your model. Provide a default value for it to be an empty array.
 
 ```js
 // myapp/models/photo-album.js
 export default DS.Model.extend({
-  photos: DS.attr('attachment');
+  photos: DS.attr('attachment', {
+    defaultValue: function() {
+      return [];
+    }
+  });
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ export default Ember.Route.extend({
 
 ## Attachments
 
-`Ember-Pouch` provides an `attachment` transform for your models, which makes working with attachments is as simple as working with any other field.
+`Ember-Pouch` provides an `attachment` transform for your models, which makes working with attachments as simple as working with any other field.
 
 Add a `DS.attr('attachment')` field to your model:
 

--- a/addon/transforms/attachment.js
+++ b/addon/transforms/attachment.js
@@ -1,0 +1,37 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+
+const { isNone } = Ember;
+const keys = Object.keys || Ember.keys;
+
+export default DS.Transform.extend({
+  deserialize: function(serialized) {
+    if (isNone(serialized)) { return null; }
+
+    return keys(serialized).map(function (attachmentName) {
+      return Ember.Object.create({
+        name: attachmentName,
+        content_type: serialized[attachmentName]['content_type'],
+        data: serialized[attachmentName]['data'],
+        stub: serialized[attachmentName]['stub'],
+      });
+    });
+  },
+
+  serialize: function(deserialized) {
+    if (!Ember.isArray(deserialized)) { return null; }
+
+    return deserialized.reduce(function (acc, attachment) {
+      const serialized = {
+        content_type: attachment.get('content_type'),
+      };
+      if (attachment.get('stub')) {
+        serialized.stub = true;
+      } else {
+        serialized.data = attachment.get('data');
+      }
+      acc[attachment.get('name')] = serialized;
+      return acc;
+    }, {});
+  }
+});

--- a/addon/transforms/attachment.js
+++ b/addon/transforms/attachment.js
@@ -14,6 +14,8 @@ export default DS.Transform.extend({
         content_type: serialized[attachmentName]['content_type'],
         data: serialized[attachmentName]['data'],
         stub: serialized[attachmentName]['stub'],
+        length: serialized[attachmentName]['length'],
+        digest: serialized[attachmentName]['digest']
       });
     });
   },
@@ -27,6 +29,8 @@ export default DS.Transform.extend({
       };
       if (attachment.get('stub')) {
         serialized.stub = true;
+        serialized.length = attachment.get('length');
+        serialized.digest = attachment.get('digest');
       } else {
         serialized.data = attachment.get('data');
       }

--- a/addon/transforms/attachment.js
+++ b/addon/transforms/attachment.js
@@ -6,7 +6,7 @@ const keys = Object.keys || Ember.keys;
 
 export default DS.Transform.extend({
   deserialize: function(serialized) {
-    if (isNone(serialized)) { return null; }
+    if (isNone(serialized)) { return []; }
 
     return keys(serialized).map(function (attachmentName) {
       return Ember.Object.create({

--- a/app/transforms/attachment.js
+++ b/app/transforms/attachment.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-pouch/transforms/attachment';

--- a/tests/unit/transforms/attachment-test.js
+++ b/tests/unit/transforms/attachment-test.js
@@ -22,6 +22,7 @@ let testDeserializedData = [
     name: 'hello.txt',
     content_type: 'text/plain',
     data: 'aGVsbG8gd29ybGQ=',
+    digest: 'md5-7mkg+nM0HN26sZkLN8KVSA=='
   }),
   Ember.Object.create({
     name: 'stub.txt',

--- a/tests/unit/transforms/attachment-test.js
+++ b/tests/unit/transforms/attachment-test.js
@@ -3,26 +3,32 @@ import { moduleFor, test } from 'ember-qunit';
 import Ember from 'ember';
 
 let testSerializedData = {
-  'test.txt': {
+  'hello.txt': {
     content_type: 'text/plain',
-    data: 'hello world!'
+    data: 'aGVsbG8gd29ybGQ=',
+    digest: "md5-7mkg+nM0HN26sZkLN8KVSA=="
+    // CouchDB doesn't add 'length'
   },
-  'stub.json': {
+  'stub.txt': {
     stub: true,
-    content_type: 'application/json'
-  }
+    content_type: 'text/plain',
+    digest: "md5-7mkg+nM0HN26sZkLN8KVSA==",
+    length: 11
+  },
 };
 
 let testDeserializedData = [
   Ember.Object.create({
-    name: 'test.txt',
+    name: 'hello.txt',
     content_type: 'text/plain',
-    data: 'hello world!'
+    data: 'aGVsbG8gd29ybGQ=',
   }),
   Ember.Object.create({
-    name: 'stub.json',
-    content_type: 'application/json',
-    stub: true
+    name: 'stub.txt',
+    content_type: 'text/plain',
+    stub: true,
+    digest: 'md5-7mkg+nM0HN26sZkLN8KVSA==',
+    length: 11
   })
 ];
 
@@ -34,13 +40,14 @@ test('it serializes an attachment', function(assert) {
   assert.equal(transform.serialize(undefined), null);
 
   let serializedData = transform.serialize(testDeserializedData);
-  let name = testDeserializedData[0].get('name');
 
-  assert.equal(serializedData[name].content_type, testSerializedData[name].content_type);
-  assert.equal(serializedData[name].data, testSerializedData[name].data);
+  let hello = testDeserializedData[0].get('name');
+  assert.equal(hello, 'hello.txt');
+  assert.equal(serializedData[hello].content_type, testSerializedData[hello].content_type);
+  assert.equal(serializedData[hello].data, testSerializedData[hello].data);
 
   let stub = testDeserializedData[1].get('name');
-
+  assert.equal(stub, 'stub.txt');
   assert.equal(serializedData[stub].content_type, testSerializedData[stub].content_type);
   assert.equal(serializedData[stub].stub, true);
 });
@@ -55,8 +62,11 @@ test('it deserializes an attachment', function(assert) {
   assert.equal(deserializedData[0].get('name'), testDeserializedData[0].get('name'));
   assert.equal(deserializedData[0].get('content_type'), testDeserializedData[0].get('content_type'));
   assert.equal(deserializedData[0].get('data'), testDeserializedData[0].get('data'));
+  assert.equal(deserializedData[0].get('digest'), testDeserializedData[0].get('digest'));
 
   assert.equal(deserializedData[1].get('name'), testDeserializedData[1].get('name'));
   assert.equal(deserializedData[1].get('content_type'), testDeserializedData[1].get('content_type'));
   assert.equal(deserializedData[1].get('stub'), true);
+  assert.equal(deserializedData[1].get('digest'), testDeserializedData[1].get('digest'));
+  assert.equal(deserializedData[1].get('length'), testDeserializedData[1].get('length'));
 });

--- a/tests/unit/transforms/attachment-test.js
+++ b/tests/unit/transforms/attachment-test.js
@@ -39,6 +39,7 @@ test('it serializes an attachment', function(assert) {
   let transform = this.subject();
   assert.equal(transform.serialize(null), null);
   assert.equal(transform.serialize(undefined), null);
+  assert.deepEqual(transform.serialize([]), {});
 
   let serializedData = transform.serialize(testDeserializedData);
 
@@ -55,8 +56,8 @@ test('it serializes an attachment', function(assert) {
 
 test('it deserializes an attachment', function(assert) {
   let transform = this.subject();
-  assert.equal(transform.deserialize(null), null);
-  assert.equal(transform.deserialize(undefined), null);
+  assert.deepEqual(transform.deserialize(null), []);
+  assert.deepEqual(transform.deserialize(undefined), []);
 
   let deserializedData = transform.deserialize(testSerializedData);
 

--- a/tests/unit/transforms/attachment-test.js
+++ b/tests/unit/transforms/attachment-test.js
@@ -6,6 +6,10 @@ let testSerializedData = {
   'test.txt': {
     content_type: 'text/plain',
     data: 'hello world!'
+  },
+  'stub.json': {
+    stub: true,
+    content_type: 'application/json'
   }
 };
 
@@ -14,6 +18,11 @@ let testDeserializedData = [
     name: 'test.txt',
     content_type: 'text/plain',
     data: 'hello world!'
+  }),
+  Ember.Object.create({
+    name: 'stub.json',
+    content_type: 'application/json',
+    stub: true
   })
 ];
 
@@ -25,10 +34,15 @@ test('it serializes an attachment', function(assert) {
   assert.equal(transform.serialize(undefined), null);
 
   let serializedData = transform.serialize(testDeserializedData);
-  let name = testDeserializedData[0].name;
+  let name = testDeserializedData[0].get('name');
 
   assert.equal(serializedData[name].content_type, testSerializedData[name].content_type);
   assert.equal(serializedData[name].data, testSerializedData[name].data);
+
+  let stub = testDeserializedData[1].get('name');
+
+  assert.equal(serializedData[stub].content_type, testSerializedData[stub].content_type);
+  assert.equal(serializedData[stub].stub, true);
 });
 
 test('it deserializes an attachment', function(assert) {
@@ -41,4 +55,8 @@ test('it deserializes an attachment', function(assert) {
   assert.equal(deserializedData[0].get('name'), testDeserializedData[0].get('name'));
   assert.equal(deserializedData[0].get('content_type'), testDeserializedData[0].get('content_type'));
   assert.equal(deserializedData[0].get('data'), testDeserializedData[0].get('data'));
+
+  assert.equal(deserializedData[1].get('name'), testDeserializedData[1].get('name'));
+  assert.equal(deserializedData[1].get('content_type'), testDeserializedData[1].get('content_type'));
+  assert.equal(deserializedData[1].get('stub'), true);
 });

--- a/tests/unit/transforms/attachment-test.js
+++ b/tests/unit/transforms/attachment-test.js
@@ -1,0 +1,44 @@
+import { moduleFor, test } from 'ember-qunit';
+
+import Ember from 'ember';
+
+let testSerializedData = {
+  'test.txt': {
+    content_type: 'text/plain',
+    data: 'hello world!'
+  }
+};
+
+let testDeserializedData = [
+  Ember.Object.create({
+    name: 'test.txt',
+    content_type: 'text/plain',
+    data: 'hello world!'
+  })
+];
+
+moduleFor('transform:attachment', 'Unit | Transform | attachment', {});
+
+test('it serializes an attachment', function(assert) {
+  let transform = this.subject();
+  assert.equal(transform.serialize(null), null);
+  assert.equal(transform.serialize(undefined), null);
+
+  let serializedData = transform.serialize(testDeserializedData);
+  let name = testDeserializedData[0].name;
+
+  assert.equal(serializedData[name].content_type, testSerializedData[name].content_type);
+  assert.equal(serializedData[name].data, testSerializedData[name].data);
+});
+
+test('it deserializes an attachment', function(assert) {
+  let transform = this.subject();
+  assert.equal(transform.deserialize(null), null);
+  assert.equal(transform.deserialize(undefined), null);
+
+  let deserializedData = transform.deserialize(testSerializedData);
+
+  assert.equal(deserializedData[0].get('name'), testDeserializedData[0].get('name'));
+  assert.equal(deserializedData[0].get('content_type'), testDeserializedData[0].get('content_type'));
+  assert.equal(deserializedData[0].get('data'), testDeserializedData[0].get('data'));
+});


### PR DESCRIPTION
Includes support for preserving `digest` and `length` of `stub: true` attachments.

This is like #97, only a bit better. :)