### PR TITLE
Attachments transform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
     - node_modules
 
 env:
-  - EMBER_TRY_SCENARIO=ember-data-1.13
   - EMBER_TRY_SCENARIO=ember-data-2.0
   - EMBER_TRY_SCENARIO=ember-data-2.1
   - EMBER_TRY_SCENARIO=ember-data-2.2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,21 @@ For more on PouchDB, check out [pouchdb.com](http://pouchdb.com).
 
 ## Install and setup
 
-    ember install ember-pouch
+```bash
+ember install ember-pouch
+```
+
+For ember-data < 2.0:
+
+```bash
+ember install ember-pouch@3.2.1
+```
+
+For ember-cli < 1.13.0:
+
+```bash
+npm install ember-pouch --save-dev
+```
 
 This provides
 - `import PouchDB from 'pouchdb'`

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Attach new files by adding an `Ember.Object` with a `.name`, `.content_type` and
 myAlbum.get('photos').addObject(Ember.Object.create({
   'name': 'kitten.jpg',
   'content_type': 'image/jpg',
-  'data': data // ... can be a DOM File, Blob, or plain old String
+  'data': btoa('hello world') // base64-encoded `String`, or a DOM `Blob`, or a `File`
 }));
 ```
 

--- a/README.md
+++ b/README.md
@@ -186,12 +186,16 @@ export default Ember.Route.extend({
 
 `Ember-Pouch` provides an `attachment` transform for your models, which makes working with attachments as simple as working with any other field.
 
-Add a `DS.attr('attachment')` field to your model:
+Add a `DS.attr('attachment')` field to your model. Provide a default value for it to be an empty array.
 
 ```js
 // myapp/models/photo-album.js
 export default DS.Model.extend({
-  photos: DS.attr('attachment');
+  photos: DS.attr('attachment', {
+    defaultValue: function() {
+      return [];
+    }
+  });
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,39 @@ export default Ember.Route.extend({
     }
   }
 });
+```
 
+## Attachments
+
+`Ember-Pouch` provides an `attachment` transform for your models, which makes working with attachments is as simple as working with any other field.
+
+Add a `DS.attr('attachment')` field to your model:
+
+```js
+// myapp/models/photo-album.js
+export default DS.Model.extend({
+  photos: DS.attr('attachment');
+});
+```
+
+Here, instances of `PhotoAlbum` have a `photos` field, which is an array of plain `Ember.Object`s, which have a `.name` and `.content_type`. Non-stubbed attachment also have a `.data` field; and stubbed attachments have a `.stub` instead.
+```handlebars
+<ul>
+  {{#each myalbum.photos as |photo|}}
+    <li>{{photo.name}}</li>
+  {{/each}}
+</ul>
+```
+
+Attach new files by adding an `Ember.Object` with a `.name`, `.content_type` and `.data` to array of attachments.
+
+```js
+// somewhere in your controller/component:
+myAlbum.get('photos').addObject(Ember.Object.create({
+  'name': 'kitten.jpg',
+  'content_type': 'image/jpg',
+  'data': data // ... can be a DOM File, Blob, or plain old String
+}));
 ```
 
 ## Sample app

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ export default Ember.Route.extend({
 
 ## Attachments
 
-`Ember-Pouch` provides an `attachment` transform for your models, which makes working with attachments is as simple as working with any other field.
+`Ember-Pouch` provides an `attachment` transform for your models, which makes working with attachments as simple as working with any other field.
 
 Add a `DS.attr('attachment')` field to your model:
 

--- a/addon/serializers/pouch.js
+++ b/addon/serializers/pouch.js
@@ -3,7 +3,6 @@ import DS from 'ember-data';
 
 const {
   get,
-  assign
 } = Ember;
 const keys = Object.keys || Ember.keys;
 
@@ -42,9 +41,9 @@ export default DS.RESTSerializer.extend({
       // of the document.
       // This will conflict with any 'attachments' attr in the model. Suggest that
       // #toRawDoc in relational-pouch should allow _attachments to be specified
-      json.attachments = assign(Object(), json.attachments || {}, json[payloadKey]); // jshint ignore:line
+      json.attachments = Object.assign({}, json.attachments || {}, json[payloadKey]); // jshint ignore:line
       json[payloadKey] = keys(json[payloadKey]).reduce((attr, fileName) => {
-        attr[fileName] = assign(Object(), json[payloadKey][fileName]); // jshint ignore:line
+        attr[fileName] = Object.assign({}, json[payloadKey][fileName]); // jshint ignore:line
         delete attr[fileName].data;
         delete attr[fileName].content_type;
         return attr;

--- a/addon/serializers/pouch.js
+++ b/addon/serializers/pouch.js
@@ -1,4 +1,10 @@
+import Ember from 'ember';
 import DS from 'ember-data';
+
+const {
+  get
+} = Ember;
+const keys = Object.keys || Ember.keys;
 
 export default DS.RESTSerializer.extend({
   _shouldSerializeHasMany: function() {
@@ -15,5 +21,41 @@ export default DS.RESTSerializer.extend({
     if (!json[key]) {
       json[key] = [];
     }
+  },
+
+  _isAttachment(attribute) {
+    return ['attachment', 'attachments'].indexOf(attribute.type) !== -1;
+  },
+
+  serializeAttribute(snapshot, json, key, attribute) {
+    this._super(snapshot, json, key, attribute);
+    if (this._isAttachment(attribute)) {
+      // if provided, use the mapping provided by `attrs` in the serializer
+      var payloadKey = this._getMappedKey(key, snapshot.type);
+      if (payloadKey === key && this.keyForAttribute) {
+        payloadKey = this.keyForAttribute(key, 'serialize');
+      }
+      // assign any attachments to the attachments property, so that relational-pouch
+      // will put these in the special CouchDB _attachments property
+      // this will conflict with any 'attachments' attr in the model
+      // suggest that #toRawDoc in relational-pouch should allow _attachments to be specified
+      json['attachments'] = Object.assign({}, json['attachments'], json[payloadKey]);
+    }
+  },
+
+  extractAttributes(modelClass, resourceHash) {
+    let attributes = this._super(modelClass, resourceHash);
+    let modelAttrs = get(modelClass, 'attributes');
+    modelClass.eachTransformedAttribute(key => {
+      let attribute = modelAttrs.get(key);
+      if (this._isAttachment(attribute)) {
+        // put the corresponding _attachments entries from the response into the attribute
+        let fileNames = keys(attributes[key]);
+        fileNames.forEach(fileName => {
+          attributes[key][fileName] = resourceHash.attachments[fileName];
+        });
+      }
+    });
+    return attributes;
   }
 });

--- a/addon/serializers/pouch.js
+++ b/addon/serializers/pouch.js
@@ -35,11 +35,19 @@ export default DS.RESTSerializer.extend({
       if (payloadKey === key && this.keyForAttribute) {
         payloadKey = this.keyForAttribute(key, 'serialize');
       }
-      // assign any attachments to the attachments property, so that relational-pouch
-      // will put these in the special CouchDB _attachments property
-      // this will conflict with any 'attachments' attr in the model
-      // suggest that #toRawDoc in relational-pouch should allow _attachments to be specified
+
+      // Merge any attachments in this attribute into the `attachments` property.
+      // relational-pouch will put these in the special CouchDB `_attachments` property
+      // of the document.
+      // This will conflict with any 'attachments' attr in the model. Suggest that
+      // #toRawDoc in relational-pouch should allow _attachments to be specified
       json['attachments'] = Object.assign({}, json['attachments'], json[payloadKey]);
+      json[payloadKey] = Object.keys(json[payloadKey]).reduce((attr, fileName) => {
+        attr[fileName] = Object.assign({}, json[payloadKey][fileName]);
+        delete attr[fileName].data;
+        delete attr[fileName].content_type;
+        return attr;
+      }, {});
     }
   },
 

--- a/addon/serializers/pouch.js
+++ b/addon/serializers/pouch.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import DS from 'ember-data';
 
 const {
-  get
+  get,
+  assign
 } = Ember;
 const keys = Object.keys || Ember.keys;
 
@@ -41,9 +42,9 @@ export default DS.RESTSerializer.extend({
       // of the document.
       // This will conflict with any 'attachments' attr in the model. Suggest that
       // #toRawDoc in relational-pouch should allow _attachments to be specified
-      json['attachments'] = Object.assign({}, json['attachments'], json[payloadKey]);
-      json[payloadKey] = Object.keys(json[payloadKey]).reduce((attr, fileName) => {
-        attr[fileName] = Object.assign({}, json[payloadKey][fileName]);
+      json.attachments = assign(Object(), json.attachments || {}, json[payloadKey]); // jshint ignore:line
+      json[payloadKey] = keys(json[payloadKey]).reduce((attr, fileName) => {
+        attr[fileName] = assign(Object(), json[payloadKey][fileName]); // jshint ignore:line
         delete attr[fileName].data;
         delete attr[fileName].content_type;
         return attr;

--- a/addon/transforms/attachment.js
+++ b/addon/transforms/attachment.js
@@ -1,0 +1,37 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+
+const { isNone } = Ember;
+const keys = Object.keys || Ember.keys;
+
+export default DS.Transform.extend({
+  deserialize: function(serialized) {
+    if (isNone(serialized)) { return null; }
+
+    return keys(serialized).map(function (attachmentName) {
+      return Ember.Object.create({
+        name: attachmentName,
+        content_type: serialized[attachmentName]['content_type'],
+        data: serialized[attachmentName]['data'],
+        stub: serialized[attachmentName]['stub'],
+      });
+    });
+  },
+
+  serialize: function(deserialized) {
+    if (!Ember.isArray(deserialized)) { return null; }
+
+    return deserialized.reduce(function (acc, attachment) {
+      const serialized = {
+        content_type: attachment.get('content_type'),
+      };
+      if (attachment.get('stub')) {
+        serialized.stub = true;
+      } else {
+        serialized.data = attachment.get('data');
+      }
+      acc[attachment.get('name')] = serialized;
+      return acc;
+    }, {});
+  }
+});

--- a/addon/transforms/attachment.js
+++ b/addon/transforms/attachment.js
@@ -1,44 +1,16 @@
 import Ember from 'ember';
-import DS from 'ember-data';
+import AttachmentsTransform from './attachments';
 
 const {
-  get,
   isNone
 } = Ember;
-const keys = Object.keys || Ember.keys;
 
-export default DS.Transform.extend({
+export default AttachmentsTransform.extend({
   deserialize: function(serialized) {
-    if (isNone(serialized)) { return []; }
-
-    return keys(serialized).map(function (attachmentName) {
-      return Ember.Object.create({
-        name: attachmentName,
-        content_type: serialized[attachmentName]['content_type'],
-        data: serialized[attachmentName]['data'],
-        stub: serialized[attachmentName]['stub'],
-        length: serialized[attachmentName]['length'],
-        digest: serialized[attachmentName]['digest']
-      });
-    });
+    return this._super(serialized).pop();
   },
-
   serialize: function(deserialized) {
-    if (!Ember.isArray(deserialized)) { return null; }
-
-    return deserialized.reduce(function (acc, attachment) {
-      const serialized = {
-        content_type: get(attachment, 'content_type'),
-      };
-      if (get(attachment, 'stub')) {
-        serialized.stub = true;
-        serialized.length = get(attachment, 'length');
-        serialized.digest = get(attachment, 'digest');
-      } else {
-        serialized.data = get(attachment, 'data');
-      }
-      acc[get(attachment, 'name')] = serialized;
-      return acc;
-    }, {});
+    if (isNone(deserialized)) { return null; }
+    return this._super([deserialized]);
   }
 });

--- a/addon/transforms/attachment.js
+++ b/addon/transforms/attachment.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-const { isNone } = Ember;
+const {
+  get,
+  isNone
+} = Ember;
 const keys = Object.keys || Ember.keys;
 
 export default DS.Transform.extend({
@@ -25,16 +28,16 @@ export default DS.Transform.extend({
 
     return deserialized.reduce(function (acc, attachment) {
       const serialized = {
-        content_type: attachment.get('content_type'),
+        content_type: get(attachment, 'content_type'),
       };
-      if (attachment.get('stub')) {
+      if (get(attachment, 'stub')) {
         serialized.stub = true;
-        serialized.length = attachment.get('length');
-        serialized.digest = attachment.get('digest');
+        serialized.length = get(attachment, 'length');
+        serialized.digest = get(attachment, 'digest');
       } else {
-        serialized.data = attachment.get('data');
+        serialized.data = get(attachment, 'data');
       }
-      acc[attachment.get('name')] = serialized;
+      acc[get(attachment, 'name')] = serialized;
       return acc;
     }, {});
   }

--- a/addon/transforms/attachment.js
+++ b/addon/transforms/attachment.js
@@ -14,6 +14,8 @@ export default DS.Transform.extend({
         content_type: serialized[attachmentName]['content_type'],
         data: serialized[attachmentName]['data'],
         stub: serialized[attachmentName]['stub'],
+        length: serialized[attachmentName]['length'],
+        digest: serialized[attachmentName]['digest']
       });
     });
   },
@@ -27,6 +29,8 @@ export default DS.Transform.extend({
       };
       if (attachment.get('stub')) {
         serialized.stub = true;
+        serialized.length = attachment.get('length');
+        serialized.digest = attachment.get('digest');
       } else {
         serialized.data = attachment.get('data');
       }

--- a/addon/transforms/attachment.js
+++ b/addon/transforms/attachment.js
@@ -6,7 +6,7 @@ const keys = Object.keys || Ember.keys;
 
 export default DS.Transform.extend({
   deserialize: function(serialized) {
-    if (isNone(serialized)) { return null; }
+    if (isNone(serialized)) { return []; }
 
     return keys(serialized).map(function (attachmentName) {
       return Ember.Object.create({

--- a/addon/transforms/attachments.js
+++ b/addon/transforms/attachments.js
@@ -12,13 +12,14 @@ export default DS.Transform.extend({
     if (isNone(serialized)) { return []; }
 
     return keys(serialized).map(function (attachmentName) {
+      let attachment = serialized[attachmentName];
       return Ember.Object.create({
         name: attachmentName,
-        content_type: serialized[attachmentName]['content_type'],
-        data: serialized[attachmentName]['data'],
-        stub: serialized[attachmentName]['stub'],
-        length: serialized[attachmentName]['length'],
-        digest: serialized[attachmentName]['digest']
+        content_type: attachment.content_type,
+        data: attachment.data,
+        stub: attachment.stub,
+        length: attachment.length,
+        digest: attachment.digest,
       });
     });
   },
@@ -34,8 +35,10 @@ export default DS.Transform.extend({
         serialized.stub = true;
         serialized.length = get(attachment, 'length');
         serialized.digest = get(attachment, 'digest');
-      } else {
+      }
+      else {
         serialized.data = get(attachment, 'data');
+        serialized.length = get(attachment, 'length');
       }
       acc[get(attachment, 'name')] = serialized;
       return acc;

--- a/addon/transforms/attachments.js
+++ b/addon/transforms/attachments.js
@@ -1,0 +1,44 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+
+const {
+  get,
+  isNone
+} = Ember;
+const keys = Object.keys || Ember.keys;
+
+export default DS.Transform.extend({
+  deserialize: function(serialized) {
+    if (isNone(serialized)) { return []; }
+
+    return keys(serialized).map(function (attachmentName) {
+      return Ember.Object.create({
+        name: attachmentName,
+        content_type: serialized[attachmentName]['content_type'],
+        data: serialized[attachmentName]['data'],
+        stub: serialized[attachmentName]['stub'],
+        length: serialized[attachmentName]['length'],
+        digest: serialized[attachmentName]['digest']
+      });
+    });
+  },
+
+  serialize: function(deserialized) {
+    if (!Ember.isArray(deserialized)) { return null; }
+
+    return deserialized.reduce(function (acc, attachment) {
+      const serialized = {
+        content_type: get(attachment, 'content_type'),
+      };
+      if (get(attachment, 'stub')) {
+        serialized.stub = true;
+        serialized.length = get(attachment, 'length');
+        serialized.digest = get(attachment, 'digest');
+      } else {
+        serialized.data = get(attachment, 'data');
+      }
+      acc[get(attachment, 'name')] = serialized;
+      return acc;
+    }, {});
+  }
+});

--- a/app/transforms/attachment.js
+++ b/app/transforms/attachment.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-pouch/transforms/attachment';

--- a/app/transforms/attachments.js
+++ b/app/transforms/attachments.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-pouch/transforms/attachments';

--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,7 @@
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0",
     "pouchdb": "^5.4.5",
-    "relational-pouch": "^1.4.4"
+    "relational-pouch": "^1.4.4",
+    "phantomjs-polyfill-object-assign": "chuckplantain/phantomjs-polyfill-object-assign"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,17 +1,6 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-data-1.13',
-      dependencies: {
-        'ember': '1.13.11',
-        'ember-data': '1.13.15',
-        'ember-cli-shims': '0.0.6'
-      },
-      resolutions: {
-        'ember': '1.13.11'
-      }
-    },
-    {
       name: 'ember-data-2.0',
       dependencies: {
         'ember': '2.0.2',

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,5 +14,9 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
+  app.import('bower_components/phantomjs-polyfill-object-assign/object-assign-polyfill.js', {
+    type: 'test'
+  });
+
   return app.toTree();
 };

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function satisfactoryEmberDataVersion(addon) {
   var checker = new VersionChecker(addon),
       bowerEmberData = checker.for('ember-data', 'bower'),
       npmEmberData = checker.for('ember-data', 'npm');
-  return npmEmberData.isAbove('2.2.99') || bowerEmberData.isAbove('1.12.99');
+  return npmEmberData.isAbove('2.2.99') || bowerEmberData.isAbove('1.13.16');
 }
 
 module.exports = {

--- a/tests/dummy/app/adapters/taco-salad.js
+++ b/tests/dummy/app/adapters/taco-salad.js
@@ -33,7 +33,9 @@ export default Adapter.extend({
     let store = this.get('store');
     let recordTypeName = this.getRecordTypeName(store.modelFor(obj.type));
     this.get('db').rel.find(recordTypeName, obj.id).then(function(doc){
-      store.pushPayload(recordTypeName, doc);
+      Ember.run(function() {
+        store.pushPayload(recordTypeName, doc);
+      });
     });
   }
 });

--- a/tests/dummy/app/models/taco-recipe.js
+++ b/tests/dummy/app/models/taco-recipe.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  rev: DS.attr('string'),
+
+  coverImage: DS.attr('attachment'),
+  photos: DS.attr('attachments')
+});

--- a/tests/dummy/app/serializers/taco-recipe.js
+++ b/tests/dummy/app/serializers/taco-recipe.js
@@ -1,0 +1,8 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  attrs: {
+    coverImage: 'cover_image',
+    photos: { key: 'photo_gallery' }
+  }
+});

--- a/tests/integration/serializers/pouch-test.js
+++ b/tests/integration/serializers/pouch-test.js
@@ -28,7 +28,7 @@ let photo2 = {
 };
 
 test('puts attachments into the `attachments` property when saving', function (assert) {
-  assert.expect(10);
+  assert.expect(11);
 
   var done = assert.async();
   Ember.RSVP.Promise.resolve().then(() => {
@@ -41,29 +41,20 @@ test('puts attachments into the `attachments` property when saving', function (a
   }).then(() => {
     return this.db().get('tacoRecipe_2_E');
   }).then((newDoc) => {
-    assert.deepEqual(newDoc._attachments, {
-      'cover.jpg': {
-        digest: 'md5-SxxZx3KOKxy2X2yyCq9c+Q==',
-        content_type: 'image/jpeg',
-        revpos: undefined,
-        stub: true,
-        length: 9
-      },
-      'photo-1.jpg': {
-        digest: 'md5-MafOMdm9kXWId0ruvo8sTA==',
-        content_type: 'image/jpeg',
-        revpos: undefined,
-        stub: true,
-        length: 11
-      },
-      'photo-2.jpg': {
-        digest: 'md5-VNkFh9jG/28rwoFW9L910g==',
-        content_type: 'image/jpeg',
-        revpos: undefined,
-        stub: true,
-        length: 11
-      }
+    function checkAttachment(attachments, fileName, value, message) {
+      delete attachments[fileName].revpos;
+      assert.deepEqual(attachments[fileName], value, message);
+    }
+    checkAttachment(newDoc._attachments, 'cover.jpg', {
+      digest: 'md5-SxxZx3KOKxy2X2yyCq9c+Q==',
+      content_type: 'image/jpeg',
+      stub: true,
+      length: 9
     }, 'attachments are placed into the _attachments property of the doc');
+    assert.deepEqual(Object.keys(newDoc._attachments).sort(),
+      [coverImage.name, photo1.name, photo2.name].sort(),
+      'all attachments are included in the _attachments property of the doc'
+    );
     assert.equal('cover_image' in newDoc.data, true,
       'respects the mapping provided by the serializer `attrs`'
     );
@@ -82,14 +73,14 @@ test('puts attachments into the `attachments` property when saving', function (a
     });
 
     var recordInStore = this.store().peekRecord('tacoRecipe', 'E');
-    let coverImage = recordInStore.get('coverImage');
-    assert.equal(coverImage.get('name'), coverImage.name);
-    assert.equal(coverImage.get('data'), coverImage.data);
+    let coverAttr = recordInStore.get('coverImage');
+    assert.equal(coverAttr.get('name'), coverImage.name);
+    assert.equal(coverAttr.get('data'), coverImage.data);
 
-    let photos = recordInStore.get('photos');
-    assert.equal(photos.length, 2, '2 photos');
-    assert.equal(photos[0].get('name'), photo1.name);
-    assert.equal(photos[0].get('data'), photo1.data);
+    let photosAttr = recordInStore.get('photos');
+    assert.equal(photosAttr.length, 2, '2 photos');
+    assert.equal(photosAttr[0].get('name'), photo1.name);
+    assert.equal(photosAttr[0].get('data'), photo1.data);
 
     done();
   }).catch((error) => {

--- a/tests/integration/serializers/pouch-test.js
+++ b/tests/integration/serializers/pouch-test.js
@@ -1,0 +1,100 @@
+import { test } from 'qunit';
+import moduleForIntegration from '../../helpers/module-for-acceptance';
+
+import Ember from 'ember';
+
+/*
+ * Tests attachments behavior for an app using the ember-pouch serializer.
+ */
+
+moduleForIntegration('Integration | Serializer | Attachments');
+
+let id = 'E';
+let coverImage = {
+  name: 'cover.jpg',
+  content_type: 'image/jpeg',
+  data: window.btoa('cover.jpg'),
+  length: 9
+};
+let photo1 = {
+  name: 'photo-1.jpg',
+  content_type: 'image/jpeg',
+  data: window.btoa('photo-1.jpg')
+};
+let photo2 = {
+  name: 'photo-2.jpg',
+  content_type: 'image/jpeg',
+  data: window.btoa('photo-2.jpg')
+};
+
+test('puts attachments into the `attachments` property when saving', function (assert) {
+  assert.expect(10);
+
+  var done = assert.async();
+  Ember.RSVP.Promise.resolve().then(() => {
+    var newRecipe = this.store().createRecord('taco-recipe', {
+      id,
+      coverImage: coverImage,
+      photos: [photo1, photo2]
+    });
+    return newRecipe.save();
+  }).then(() => {
+    return this.db().get('tacoRecipe_2_E');
+  }).then((newDoc) => {
+    assert.deepEqual(newDoc._attachments, {
+      'cover.jpg': {
+        digest: 'md5-SxxZx3KOKxy2X2yyCq9c+Q==',
+        content_type: 'image/jpeg',
+        revpos: undefined,
+        stub: true,
+        length: 9
+      },
+      'photo-1.jpg': {
+        digest: 'md5-MafOMdm9kXWId0ruvo8sTA==',
+        content_type: 'image/jpeg',
+        revpos: undefined,
+        stub: true,
+        length: 11
+      },
+      'photo-2.jpg': {
+        digest: 'md5-VNkFh9jG/28rwoFW9L910g==',
+        content_type: 'image/jpeg',
+        revpos: undefined,
+        stub: true,
+        length: 11
+      }
+    }, 'attachments are placed into the _attachments property of the doc');
+    assert.equal('cover_image' in newDoc.data, true,
+      'respects the mapping provided by the serializer `attrs`'
+    );
+    assert.deepEqual(newDoc.data.cover_image, {
+      'cover.jpg': {
+        length: 9
+      }
+    }, 'the attribute contains the file name');
+    assert.equal(newDoc.data.cover_image['cover.jpg'].length, 9,
+      'the attribute contains the length to avoid empty length when File objects are ' +
+      'saved and have not been reloaded'
+    );
+    assert.deepEqual(newDoc.data.photo_gallery, {
+      'photo-1.jpg': {},
+      'photo-2.jpg': {}
+    });
+
+    var recordInStore = this.store().peekRecord('tacoRecipe', 'E');
+    let coverImage = recordInStore.get('coverImage');
+    assert.equal(coverImage.get('name'), coverImage.name);
+    assert.equal(coverImage.get('data'), coverImage.data);
+
+    let photos = recordInStore.get('photos');
+    assert.equal(photos.length, 2, '2 photos');
+    assert.equal(photos[0].get('name'), photo1.name);
+    assert.equal(photos[0].get('data'), photo1.data);
+
+    done();
+  }).catch((error) => {
+    console.error('error in test', error);
+    assert.ok(false, 'error in test:' + error);
+    done();
+  });
+});

--- a/tests/unit/transforms/attachment-test.js
+++ b/tests/unit/transforms/attachment-test.js
@@ -22,6 +22,7 @@ let testDeserializedData = [
     name: 'hello.txt',
     content_type: 'text/plain',
     data: 'aGVsbG8gd29ybGQ=',
+    digest: 'md5-7mkg+nM0HN26sZkLN8KVSA=='
   }),
   Ember.Object.create({
     name: 'stub.txt',

--- a/tests/unit/transforms/attachment-test.js
+++ b/tests/unit/transforms/attachment-test.js
@@ -3,26 +3,32 @@ import { moduleFor, test } from 'ember-qunit';
 import Ember from 'ember';
 
 let testSerializedData = {
-  'test.txt': {
+  'hello.txt': {
     content_type: 'text/plain',
-    data: 'hello world!'
+    data: 'aGVsbG8gd29ybGQ=',
+    digest: "md5-7mkg+nM0HN26sZkLN8KVSA=="
+    // CouchDB doesn't add 'length'
   },
-  'stub.json': {
+  'stub.txt': {
     stub: true,
-    content_type: 'application/json'
-  }
+    content_type: 'text/plain',
+    digest: "md5-7mkg+nM0HN26sZkLN8KVSA==",
+    length: 11
+  },
 };
 
 let testDeserializedData = [
   Ember.Object.create({
-    name: 'test.txt',
+    name: 'hello.txt',
     content_type: 'text/plain',
-    data: 'hello world!'
+    data: 'aGVsbG8gd29ybGQ=',
   }),
   Ember.Object.create({
-    name: 'stub.json',
-    content_type: 'application/json',
-    stub: true
+    name: 'stub.txt',
+    content_type: 'text/plain',
+    stub: true,
+    digest: 'md5-7mkg+nM0HN26sZkLN8KVSA==',
+    length: 11
   })
 ];
 
@@ -34,13 +40,14 @@ test('it serializes an attachment', function(assert) {
   assert.equal(transform.serialize(undefined), null);
 
   let serializedData = transform.serialize(testDeserializedData);
-  let name = testDeserializedData[0].get('name');
 
-  assert.equal(serializedData[name].content_type, testSerializedData[name].content_type);
-  assert.equal(serializedData[name].data, testSerializedData[name].data);
+  let hello = testDeserializedData[0].get('name');
+  assert.equal(hello, 'hello.txt');
+  assert.equal(serializedData[hello].content_type, testSerializedData[hello].content_type);
+  assert.equal(serializedData[hello].data, testSerializedData[hello].data);
 
   let stub = testDeserializedData[1].get('name');
-
+  assert.equal(stub, 'stub.txt');
   assert.equal(serializedData[stub].content_type, testSerializedData[stub].content_type);
   assert.equal(serializedData[stub].stub, true);
 });
@@ -55,8 +62,11 @@ test('it deserializes an attachment', function(assert) {
   assert.equal(deserializedData[0].get('name'), testDeserializedData[0].get('name'));
   assert.equal(deserializedData[0].get('content_type'), testDeserializedData[0].get('content_type'));
   assert.equal(deserializedData[0].get('data'), testDeserializedData[0].get('data'));
+  assert.equal(deserializedData[0].get('digest'), testDeserializedData[0].get('digest'));
 
   assert.equal(deserializedData[1].get('name'), testDeserializedData[1].get('name'));
   assert.equal(deserializedData[1].get('content_type'), testDeserializedData[1].get('content_type'));
   assert.equal(deserializedData[1].get('stub'), true);
+  assert.equal(deserializedData[1].get('digest'), testDeserializedData[1].get('digest'));
+  assert.equal(deserializedData[1].get('length'), testDeserializedData[1].get('length'));
 });

--- a/tests/unit/transforms/attachment-test.js
+++ b/tests/unit/transforms/attachment-test.js
@@ -39,6 +39,7 @@ test('it serializes an attachment', function(assert) {
   let transform = this.subject();
   assert.equal(transform.serialize(null), null);
   assert.equal(transform.serialize(undefined), null);
+  assert.deepEqual(transform.serialize([]), {});
 
   let serializedData = transform.serialize(testDeserializedData);
 
@@ -55,8 +56,8 @@ test('it serializes an attachment', function(assert) {
 
 test('it deserializes an attachment', function(assert) {
   let transform = this.subject();
-  assert.equal(transform.deserialize(null), null);
-  assert.equal(transform.deserialize(undefined), null);
+  assert.deepEqual(transform.deserialize(null), []);
+  assert.deepEqual(transform.deserialize(undefined), []);
 
   let deserializedData = transform.deserialize(testSerializedData);
 

--- a/tests/unit/transforms/attachment-test.js
+++ b/tests/unit/transforms/attachment-test.js
@@ -6,6 +6,10 @@ let testSerializedData = {
   'test.txt': {
     content_type: 'text/plain',
     data: 'hello world!'
+  },
+  'stub.json': {
+    stub: true,
+    content_type: 'application/json'
   }
 };
 
@@ -14,6 +18,11 @@ let testDeserializedData = [
     name: 'test.txt',
     content_type: 'text/plain',
     data: 'hello world!'
+  }),
+  Ember.Object.create({
+    name: 'stub.json',
+    content_type: 'application/json',
+    stub: true
   })
 ];
 
@@ -25,10 +34,15 @@ test('it serializes an attachment', function(assert) {
   assert.equal(transform.serialize(undefined), null);
 
   let serializedData = transform.serialize(testDeserializedData);
-  let name = testDeserializedData[0].name;
+  let name = testDeserializedData[0].get('name');
 
   assert.equal(serializedData[name].content_type, testSerializedData[name].content_type);
   assert.equal(serializedData[name].data, testSerializedData[name].data);
+
+  let stub = testDeserializedData[1].get('name');
+
+  assert.equal(serializedData[stub].content_type, testSerializedData[stub].content_type);
+  assert.equal(serializedData[stub].stub, true);
 });
 
 test('it deserializes an attachment', function(assert) {
@@ -41,4 +55,8 @@ test('it deserializes an attachment', function(assert) {
   assert.equal(deserializedData[0].get('name'), testDeserializedData[0].get('name'));
   assert.equal(deserializedData[0].get('content_type'), testDeserializedData[0].get('content_type'));
   assert.equal(deserializedData[0].get('data'), testDeserializedData[0].get('data'));
+
+  assert.equal(deserializedData[1].get('name'), testDeserializedData[1].get('name'));
+  assert.equal(deserializedData[1].get('content_type'), testDeserializedData[1].get('content_type'));
+  assert.equal(deserializedData[1].get('stub'), true);
 });

--- a/tests/unit/transforms/attachment-test.js
+++ b/tests/unit/transforms/attachment-test.js
@@ -1,0 +1,44 @@
+import { moduleFor, test } from 'ember-qunit';
+
+import Ember from 'ember';
+
+let testSerializedData = {
+  'test.txt': {
+    content_type: 'text/plain',
+    data: 'hello world!'
+  }
+};
+
+let testDeserializedData = [
+  Ember.Object.create({
+    name: 'test.txt',
+    content_type: 'text/plain',
+    data: 'hello world!'
+  })
+];
+
+moduleFor('transform:attachment', 'Unit | Transform | attachment', {});
+
+test('it serializes an attachment', function(assert) {
+  let transform = this.subject();
+  assert.equal(transform.serialize(null), null);
+  assert.equal(transform.serialize(undefined), null);
+
+  let serializedData = transform.serialize(testDeserializedData);
+  let name = testDeserializedData[0].name;
+
+  assert.equal(serializedData[name].content_type, testSerializedData[name].content_type);
+  assert.equal(serializedData[name].data, testSerializedData[name].data);
+});
+
+test('it deserializes an attachment', function(assert) {
+  let transform = this.subject();
+  assert.equal(transform.deserialize(null), null);
+  assert.equal(transform.deserialize(undefined), null);
+
+  let deserializedData = transform.deserialize(testSerializedData);
+
+  assert.equal(deserializedData[0].get('name'), testDeserializedData[0].get('name'));
+  assert.equal(deserializedData[0].get('content_type'), testDeserializedData[0].get('content_type'));
+  assert.equal(deserializedData[0].get('data'), testDeserializedData[0].get('data'));
+});

--- a/tests/unit/transforms/attachments-test.js
+++ b/tests/unit/transforms/attachments-test.js
@@ -33,7 +33,7 @@ let testDeserializedData = [
   })
 ];
 
-moduleFor('transform:attachment', 'Unit | Transform | attachment', {});
+moduleFor('transform:attachments', 'Unit | Transform | attachments', {});
 
 test('it serializes an attachment', function(assert) {
   let transform = this.subject();


### PR DESCRIPTION
This PR contains @stevebest's changes in #135, as well as the changes that I've made.

- Add `attachment` and `attachments` transforms
- Serializer changes to support these
- Integration test that covers the new functionality.

My adapter changes are not compatible with ember-data 1.13. Unless there's a strong need to keep supporting this I suggest we drop support for this and support ember-data >= 2.x. @nolanlawson what are your thoughts on this?