### PR TITLE
Switched to npm versions of pouchdb

### DIFF
--- a/addon/initializers/pouchdb-plugin.js
+++ b/addon/initializers/pouchdb-plugin.js
@@ -1,0 +1,14 @@
+import PouchDB from 'pouchdb';
+import RelationalPouch from 'relational-pouch';
+import Find from 'pouchdb-find';
+
+export function initialize() {
+  PouchDB
+    .plugin(RelationalPouch)
+    .plugin(Find);
+}
+
+export default {
+  name: 'pouchdb-plugin',
+  initialize
+};

--- a/app/initializers/pouchdb-plugin.js
+++ b/app/initializers/pouchdb-plugin.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-pouch/initializers/pouchdb-plugin';

--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,6 @@
   "dependencies": {
     "ember": "~2.8.0",
     "ember-cli-shims": "0.1.1",
-    "pouchdb": "^5.4.5",
-    "relational-pouch": "^1.4.4",
-    "pouchdb-find": "^0.10.3",
     "phantomjs-polyfill-object-assign": "chuckplantain/phantomjs-polyfill-object-assign"
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,16 +1,23 @@
 /* jshint node: true */
 'use strict';
+const browserifyTree = require('./lib/browserify-tree');
 
 module.exports = {
   name: 'ember-pouch',
-  included(app) {
-    const bowerDir = app.bowerDirectory;
-
-    app.import(bowerDir + '/pouchdb/dist/pouchdb.js');
-    app.import(bowerDir + '/relational-pouch/dist/pouchdb.relational-pouch.js');
-    app.import(bowerDir + '/pouchdb-find/dist/pouchdb.find.js');
-    app.import('vendor/shims/pouchdb.js', {
-      exports: { 'pouchdb': [ 'default' ]}
+  treeForVendor(tree) {
+    return browserifyTree(tree, {
+      modules: [
+        {
+          module: 'pouchdb-browser',
+          resolution: 'pouchdb'
+        },
+        'relational-pouch',
+        'pouchdb-find'
+      ],
+      outputFile: 'pouchdb-browserify.js'
     });
+  },
+  included(app) {
+    app.import('vendor/pouchdb-browserify.js');
   }
 };

--- a/lib/amd-stub-generator.js
+++ b/lib/amd-stub-generator.js
@@ -17,8 +17,8 @@ function AMDStubGenerator(inputTree, options) {
 }
 
 AMDStubGenerator.prototype.build = function () {
-  var amdFileContent = this.modulesMap.map(function(moduleName) {
-    return _toAmd(moduleName);
+  var amdFileContent = this.modulesMap.map(function(module) {
+    return _toAmd(module);
   }).join('\n');
 
   this._writeAMDStub(amdFileContent);
@@ -33,6 +33,12 @@ AMDStubGenerator.prototype._writeAMDStub = function (content) {
 
 module.exports = AMDStubGenerator;
 
-function _toAmd(moduleName) {
-  return `define('${moduleName}', function(){ return { 'default': require('${moduleName}')};})`;
+function _toAmd(module) {
+  if (typeof module === 'object') {
+    var { module, resolution } = module;
+  } else {
+    var resolution = module;
+  }
+
+  return `define('${resolution}', function(){ return { 'default': require('${module}')};})`;
 }

--- a/lib/amd-stub-generator.js
+++ b/lib/amd-stub-generator.js
@@ -10,10 +10,10 @@ function AMDStubGenerator(inputTree, options) {
   }
   options = options || {};
   Plugin.call(this, [inputTree], options);
-  
+
   this.options = options;
   this.modulesMap = this.options.modules || [];
-  this.fileName = this.options.amdFileName || 'amd-to-browserify.js';
+  this.fileName = this.options.amdFileName;
 }
 
 AMDStubGenerator.prototype.build = function () {

--- a/lib/amd-stub-generator.js
+++ b/lib/amd-stub-generator.js
@@ -1,4 +1,5 @@
 /* jshint node: true */
+'use strict';
 var Plugin = require('broccoli-plugin');
 var fs = require('fs');
 
@@ -33,12 +34,16 @@ AMDStubGenerator.prototype._writeAMDStub = function (content) {
 
 module.exports = AMDStubGenerator;
 
-function _toAmd(module) {
-  if (typeof module === 'object') {
-    var { module, resolution } = module;
+function _toAmd(moduleDef) {
+  var resolution;
+  var moduleName;
+
+  if (typeof moduleDef === 'object') {
+    moduleName = moduleDef.module;
+    resolution = moduleDef.resolution;
   } else {
-    var resolution = module;
+    resolution = moduleName = moduleDef;
   }
 
-  return `define('${resolution}', function(){ return { 'default': require('${module}')};})`;
+  return `define('${resolution}', function(){ return { 'default': require('${moduleName}')};})`;
 }

--- a/lib/amd-stub-generator.js
+++ b/lib/amd-stub-generator.js
@@ -1,0 +1,38 @@
+/* jshint node: true */
+var Plugin = require('broccoli-plugin');
+var fs = require('fs');
+
+AMDStubGenerator.prototype = Object.create(Plugin.prototype);
+AMDStubGenerator.prototype.constructor = AMDStubGenerator;
+function AMDStubGenerator(inputTree, options) {
+  if (!(this instanceof AMDStubGenerator)) {
+    return new AMDStubGenerator(inputTree, options);
+  }
+  options = options || {};
+  Plugin.call(this, [inputTree], options);
+  
+  this.options = options;
+  this.modulesMap = this.options.modules || [];
+  this.fileName = this.options.amdFileName || 'amd-to-browserify.js';
+}
+
+AMDStubGenerator.prototype.build = function () {
+  var amdFileContent = this.modulesMap.map(function(moduleName) {
+    return _toAmd(moduleName);
+  }).join('\n');
+
+  this._writeAMDStub(amdFileContent);
+};
+
+AMDStubGenerator.prototype._writeAMDStub = function (content) {
+  if (content !== "") {
+    var filePath = `${this.outputPath}/${this.fileName}`;
+    fs.writeFileSync(filePath, content);
+  }
+};
+
+module.exports = AMDStubGenerator;
+
+function _toAmd(moduleName) {
+  return `define('${moduleName}', function(){ return { 'default': require('${moduleName}')};})`;
+}

--- a/lib/browserify-tree.js
+++ b/lib/browserify-tree.js
@@ -1,0 +1,23 @@
+/* jshint node: true */
+var AMDStubGenerator = require('./amd-stub-generator.js');
+var Watchify = require('broccoli-watchify');
+
+const amdFileName = 'amd-to-browserify.js';
+
+function browserifyTree(tree, options) {
+
+  var amdTree = new AMDStubGenerator(tree, {
+    modules: options.modules,
+    amdFileName
+  });
+
+  return new Watchify(amdTree, {
+    browserify: {
+      entries: [`./${amdFileName}`]
+    },
+    cache: true,
+    outputFile: options.outputFile || 'pouchdb-browserify.js'
+  });
+}
+
+module.exports = browserifyTree;

--- a/lib/browserify-tree.js
+++ b/lib/browserify-tree.js
@@ -1,8 +1,9 @@
 /* jshint node: true */
+'use strict';
 var AMDStubGenerator = require('./amd-stub-generator.js');
 var Watchify = require('broccoli-watchify');
 
-const amdFileName = 'amd-to-browserify.js';
+var amdFileName = 'amd-to-browserify.js';
 
 function browserifyTree(tree, options) {
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
+    "broccoli-plugin": "^1.2.2",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "broccoli-plugin": "^1.2.2",
+    "broccoli-watchify": "^1.0.0",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,10 @@
     "loader.js": "^4.0.1"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.1.6",
+    "pouchdb-browser": "^6.0.7",
+    "pouchdb-find": "^0.10.3",
+    "relational-pouch": "^1.4.4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/helpers/module-for-pouch-acceptance.js
+++ b/tests/helpers/module-for-pouch-acceptance.js
@@ -4,7 +4,7 @@ import destroyApp from '../helpers/destroy-app';
 import config from 'dummy/config/environment';
 
 import Ember from 'ember';
-/* globals PouchDB */
+import PouchDB from 'pouchdb';
 
 export default function(name, options = {}) {
   module(name, {

--- a/vendor/shims/pouchdb.js
+++ b/vendor/shims/pouchdb.js
@@ -1,9 +1,0 @@
-(function() {
-  function vendorModule() {
-    'use strict';
-
-    return { 'default': self['PouchDB'] };
-  }
-
-  define('pouchdb', [], vendorModule);
-})();


### PR DESCRIPTION
This PR allow to use the npm version of pouchdb and its plugins, therefore addressing #120.
In order to achieve this goal, I had to create a tiny broccolijs plugin that creates the amd wrapper and pass it to browserify. I took this idea after long searching from the awesome [ember-browserify](https://github.com/ef4/ember-browserify), so thnx to @ef4.

I hope the code speaks for itself, but I'll be glad to explain if needed
