### PR TITLE
Remove ember-getowner-polyfill

### DIFF
--- a/addon/adapters/pouch.js
+++ b/addon/adapters/pouch.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import getOwner from 'ember-getowner-polyfill';
 
 import {
   extractDeleteRecord
@@ -147,8 +146,8 @@ export default DS.RESTAdapter.extend({
     if (type.documentType) {
       schemaDef['documentType'] = type.documentType;
     }
-    
-    let config = getOwner(this).resolveRegistration('config:environment');
+
+    let config = Ember.getOwner(this).resolveRegistration('config:environment');
     let dontsavedefault = config['emberpouch'] && config['emberpouch']['dontsavehasmany'];
     // else it's new, so update
     this._schema.push(schemaDef);

--- a/addon/serializers/pouch.js
+++ b/addon/serializers/pouch.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   get,
@@ -12,8 +11,8 @@ export default DS.RESTSerializer.extend({
   
   init: function() {
   	this._super(...arguments);
-  	
-    let config = getOwner(this).resolveRegistration('config:environment');
+
+    let config = Ember.getOwner(this).resolveRegistration('config:environment');
   	this.dontsavedefault = config['emberpouch'] && config['emberpouch']['dontsavehasmany'];
   },
   

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "ember-data": "^2.8.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-getowner-polyfill": "1.0.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.1"


### PR DESCRIPTION
Ember.getOwner() has been available since Ember 2.3