### PR TITLE
update ember-getowner-polyfill to remove deprecation warnings

### DIFF
--- a/addon/adapters/pouch.js
+++ b/addon/adapters/pouch.js
@@ -1,12 +1,12 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import getOwner from 'ember-getowner-polyfill';
 
 import {
   extractDeleteRecord
 } from '../utils';
 
 const {
+  getOwner,
   run: {
     bind
   },

--- a/addon/serializers/pouch.js
+++ b/addon/serializers/pouch.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   get,
+  getOwner
 } = Ember;
 const keys = Object.keys || Ember.keys;
 const assign = Object.assign || Ember.assign;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-data": "^2.8.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-getowner-polyfill": "1.0.1",
+    "ember-getowner-polyfill": "^1.1.0",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.1"


### PR DESCRIPTION
this is less radical than #173